### PR TITLE
PHP 8.2 fixes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package packagerversion="1.4.11" version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
+<package packagerversion="1.9.5" version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
  <name>radius</name>
  <channel>pecl.php.net</channel>
  <summary>Radius client library</summary>
  <description>This package is based on the libradius of FreeBSD, with some modifications and extensions. 
 This PECL provides full support for RADIUS authentication (RFC 2865) and RADIUS accounting (RFC 2866), 
 works on Unix and on Windows. Its an easy way to authenticate your users against the user-database of your 
-OS (for example against Windows Active-Directory via IAS).
-  
- </description>
+OS (for example against Windows Active-Directory via IAS).</description>
  <lead>
   <name>Michael Bretterklieber</name>
   <user>mbretter</user>
@@ -22,92 +20,92 @@ OS (for example against Windows Active-Directory via IAS).
   <active>yes</active>
  </lead>
  <date>2016-02-15</date>
- <time>15:00:00</time>
+ <time>15:11:50</time>
  <version>
-  <release>1.3.0</release>
-  <api>1.3.0</api>
+  <release>1.4.0b1</release>
+  <api>1.4.0b1</api>
  </version>
-
  <stability>
-  <release>stable</release>
-  <api>stable</api>
+  <release>beta</release>
+  <api>beta</api>
  </stability>
  <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
  <notes>
-- Fixed bug #65156 (Please provide LICENSE file). (Adam)
-- Fixed bug #65378 (radius.c:706: error: too many arguments to function ‘rad_salt_value’). (Adam)
-- Fixed bug #65599 (Fix compiling for VC11 x64). (Jan Ehrhardt)
+- Add PHP 7.0 support. (Adam)
+- Drop support for PHP &lt; 5.3.
  </notes>
-
  <contents>
   <dir name="/">
-   <dir name="examples">
-    <file name="des.php" role="doc" />
-    <file name="mschap.php" role="doc" />
-    <file name="mschaptest.php" role="doc" />
-    <file name="radius-acct.php" role="doc" />
-    <file name="radius-auth.php" role="doc" />
-   </dir> <!-- //examples -->
-   <dir name="tests">
-    <dir name="server">
-     <file name="fake_server.php" role="test" />
-    </dir>
-    <file name="coa.phpt" role="test" />
-    <file name="disconnect.phpt" role="test" />
-    <file name="radius_acct_open.phpt" role="test" />
-    <file name="radius_auth_open.phpt" role="test" />
-    <file name="radius_close.phpt" role="test" />
-    <file name="radius_cvt_addr.phpt" role="test" />
-    <file name="radius_cvt_int.phpt" role="test" />
-    <file name="radius_cvt_string.phpt" role="test" />
-    <file name="radius_get_attr.phpt" role="test" />
-    <file name="radius_get_tagged_attr_data.phpt" role="test" />
-    <file name="radius_get_tagged_attr_tag.phpt" role="test" />
-    <file name="radius_get_vendor_attr.phpt" role="test" />
-    <file name="radius_put_addr.phpt" role="test" />
-    <file name="radius_put_addr_tag.phpt" role="test" />
-    <file name="radius_put_attr.phpt" role="test" />
-    <file name="radius_put_attr_tag.phpt" role="test" />
-    <file name="radius_put_int.phpt" role="test" />
-    <file name="radius_put_int_tag.phpt" role="test" />
-    <file name="radius_put_string.phpt" role="test" />
-    <file name="radius_put_string_tag.phpt" role="test" />
-    <file name="radius_put_vendor_addr.phpt" role="test" />
-    <file name="radius_put_vendor_addr_tag.phpt" role="test" />
-    <file name="radius_put_vendor_attr.phpt" role="test" />
-    <file name="radius_put_vendor_attr_tag.phpt" role="test" />
-    <file name="radius_put_vendor_int.phpt" role="test" />
-    <file name="radius_put_vendor_int_tag.phpt" role="test" />
-    <file name="radius_put_vendor_string.phpt" role="test" />
-    <file name="radius_put_vendor_string_tag.phpt" role="test" />
-    <file name="radius_request_authenticator.phpt" role="test" />
-    <file name="radius_salt_encrypt_attr.phpt" role="test" />
-    <file name="radius_server_secret.phpt" role="test" />
-    <file name="radius_server_secret_config.phpt" role="test" />
-   </dir>
-   <file name="config.m4" role="src" />
-   <file name="CREDITS" role="doc" />
-   <file name="LICENSE" role="doc" />
-   <file name="Makefile.in" role="src" />
-   <file name="php_radius.h" role="src" />
-   <file name="radius.c" role="src" />
-   <file name="radius.conf" role="src" />
-   <file name="radius.dsp" role="src" />
-   <file name="radius.dsw" role="src" />
-   <file name="radius_init_const.h" role="src" />
-   <file name="radlib.c" role="src" />
-   <file name="radlib.h" role="src" />
-   <file name="radlib_compat.c" role="src" />
-   <file name="radlib_compat.h" role="src" />
-   <file name="radlib_md5.h" role="src" />
-   <file name="radlib_private.h" role="src" />
-   <file name="radlib_vs.h" role="src" />
-  </dir> <!-- / -->
+   <file md5sum="1a8f43c22c7615cc509387e1a0b8f097" name="examples/des.php" role="doc" />
+   <file md5sum="075635ba5bf71bb420a1d1ca8d027285" name="examples/mschap.php" role="doc" />
+   <file md5sum="e237b87a64f1b47ac3b7efb1fe836280" name="examples/mschaptest.php" role="doc" />
+   <file md5sum="f17f9a4ec3f19e1eca79b02c7412aef8" name="examples/radius-acct.php" role="doc" />
+   <file md5sum="5406af0402f693082e729167300a7700" name="examples/radius-auth.php" role="doc" />
+   <file md5sum="86285d20163dd259ed7823d8fac9dfe4" name="pecl-compat/src/misc.h" role="src" />
+   <file md5sum="bd2b4fe3b4c053a338a24efb66a37a18" name="pecl-compat/src/zend_API.h" role="src" />
+   <file md5sum="e78c79ee5dfe4622879debc788923a2b" name="pecl-compat/src/zend_hash.h" role="src" />
+   <file md5sum="61244e4767158ab5559888a1ace59caf" name="pecl-compat/src/zend_resource.h" role="src" />
+   <file md5sum="4964d5e75b79e45810cb5e3af061f70c" name="pecl-compat/src/zend_string.h" role="src" />
+   <file md5sum="4ca10b620178ce5619fdb2985e99ebc9" name="pecl-compat/compat.h" role="src" />
+   <file md5sum="2df3b9f9a4750e44c0063e90916ea745" name="tests/server/attribute.php" role="test" />
+   <file md5sum="2c80246c2caaa10c3996220e7fc8f375" name="tests/server/fake_server.php" role="test" />
+   <file md5sum="21ef8d92199a91103fe752d72fa99eb1" name="tests/server/vsa.php" role="test" />
+   <file md5sum="48b924771a69fd92f46273fcae8fd187" name="tests/coa.phpt" role="test" />
+   <file md5sum="a9c62a0245dda571c869b3c87371d983" name="tests/disconnect.phpt" role="test" />
+   <file md5sum="d81a22d057602b283cf6f2fd659f3a98" name="tests/radius_acct_open.phpt" role="test" />
+   <file md5sum="aa16a8ae9502fdb61232da918cf7859c" name="tests/radius_auth_open.phpt" role="test" />
+   <file md5sum="dbb9a3ec2f437cc7232ac365c9217a73" name="tests/radius_close.phpt" role="test" />
+   <file md5sum="e31938e300c2670c9e2aedac192c3a43" name="tests/radius_cvt_addr.phpt" role="test" />
+   <file md5sum="9184b60a4367cfb91a206ffb7939328d" name="tests/radius_cvt_int.phpt" role="test" />
+   <file md5sum="504aa4580902bb81e94cbed1038c47ed" name="tests/radius_cvt_string.phpt" role="test" />
+   <file md5sum="469b8ce2aee8ac9b07a802e59297999b" name="tests/radius_get_attr.phpt" role="test" />
+   <file md5sum="9727b3f06d433e9e63e5b00e2d17e3ef" name="tests/radius_get_tagged_attr_data.phpt" role="test" />
+   <file md5sum="5af511f6ef450ea3b9cde12b45bd7ee9" name="tests/radius_get_tagged_attr_tag.phpt" role="test" />
+   <file md5sum="f4d9102f9e1c27566672a034f935664e" name="tests/radius_get_vendor_attr.phpt" role="test" />
+   <file md5sum="aa9ab53597e7f6143c9743a70ffd805f" name="tests/radius_put_addr.phpt" role="test" />
+   <file md5sum="3c155f522fd329a5cc03b8a7bb768bb6" name="tests/radius_put_addr_tag.phpt" role="test" />
+   <file md5sum="0187d47b7284056167871e72b879699e" name="tests/radius_put_attr.phpt" role="test" />
+   <file md5sum="39eb3fc284f97ae04d364fe31f41c875" name="tests/radius_put_attr_tag.phpt" role="test" />
+   <file md5sum="73b8a2233052aed98cc9881fc0f40dfe" name="tests/radius_put_int.phpt" role="test" />
+   <file md5sum="967d89c64158286b16d7241049503c46" name="tests/radius_put_int_tag.phpt" role="test" />
+   <file md5sum="1133b5d87925c41e5782e908b119c142" name="tests/radius_put_string.phpt" role="test" />
+   <file md5sum="b218b16f8b791fda5b4f011f6e03bf8f" name="tests/radius_put_string_tag.phpt" role="test" />
+   <file md5sum="1e71285d5a6cf1bd85b9509e70b703cb" name="tests/radius_put_vendor_addr.phpt" role="test" />
+   <file md5sum="faff3d48fa19c28acc2482ebfa05196c" name="tests/radius_put_vendor_addr_tag.phpt" role="test" />
+   <file md5sum="4c74625810a583aae3e25ebd90d00d8b" name="tests/radius_put_vendor_attr.phpt" role="test" />
+   <file md5sum="b49a0d4cd7327ecd32649623474fb958" name="tests/radius_put_vendor_attr_tag.phpt" role="test" />
+   <file md5sum="e95c9defa53a7b8d5e7e5f839c511a3e" name="tests/radius_put_vendor_int.phpt" role="test" />
+   <file md5sum="48f771ff2feec2725c7a5ad155e013c0" name="tests/radius_put_vendor_int_tag.phpt" role="test" />
+   <file md5sum="efc4f5aa85429151d6cb94866e23e871" name="tests/radius_put_vendor_string.phpt" role="test" />
+   <file md5sum="f17361f634bc427cc0076ffae45a4aef" name="tests/radius_put_vendor_string_tag.phpt" role="test" />
+   <file md5sum="7d61d08c3ccb8448ff0f5a0e6c77fc90" name="tests/radius_request_authenticator.phpt" role="test" />
+   <file md5sum="1cc00eb0f52ed74c9ab0b51da1cbafb8" name="tests/radius_salt_encrypt_attr.phpt" role="test" />
+   <file md5sum="8612d249e2611a260960f24d0950709c" name="tests/radius_server_secret.phpt" role="test" />
+   <file md5sum="9c23f62808ee602a889ac6b2ff7c561e" name="tests/radius_server_secret_config.phpt" role="test" />
+   <file md5sum="52b1f8bab8ceef10d52f80c1242f37d1" name="config.m4" role="src" />
+   <file md5sum="a4765ae26f6116be665ee4c97d3ef496" name="config.w32" role="src" />
+   <file md5sum="9ab005d49da8ea33b4fddb62a7ba374c" name="CREDITS" role="doc" />
+   <file md5sum="1e50d4afb32d20d3c990cb41976da9ab" name="LICENSE" role="doc" />
+   <file md5sum="9e30411dec8d2c49b771d48750927202" name="Makefile.in" role="src" />
+   <file md5sum="5e9da3f2158123abf6833d9c5ad50418" name="php_radius.h" role="src" />
+   <file md5sum="ac38fdd33abdfea8bbf02917c1d02e3b" name="radius.c" role="src" />
+   <file md5sum="32314145ab4a36966dade15c2261a51a" name="radius.conf" role="src" />
+   <file md5sum="a01a9e5453ddccebc5efe87099c24b73" name="radius.dsp" role="src" />
+   <file md5sum="c7b1fcf55179bf615e35742eb3f3769c" name="radius.dsw" role="src" />
+   <file md5sum="bc43e393a7c2a747b5964a9c5aee0d8c" name="radius_init_const.h" role="src" />
+   <file md5sum="3feafe670018cb923a827b620e641116" name="radlib.c" role="src" />
+   <file md5sum="67315cdd8a1fb01f714a0fe66e6ae9ea" name="radlib.h" role="src" />
+   <file md5sum="732ba9cd1657b19cd8479fc1e7081249" name="radlib_compat.c" role="src" />
+   <file md5sum="22c192f920625f529a77d79df529d185" name="radlib_compat.h" role="src" />
+   <file md5sum="99603d0ebaada124f170275804c45b01" name="radlib_md5.h" role="src" />
+   <file md5sum="6306e4a5505e89b072f1095ad1589a75" name="radlib_private.h" role="src" />
+   <file md5sum="ba0b5365fd1acaacb836743e434cd913" name="radlib_vs.h" role="src" />
+  </dir>
  </contents>
  <dependencies>
   <required>
    <php>
-    <min>4.3.0</min>
+    <min>5.3.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>
@@ -117,13 +115,27 @@ OS (for example against Windows Active-Directory via IAS).
  <providesextension>radius</providesextension>
  <extsrcrelease />
  <changelog>
-
+  <release>
+   <version>
+    <release>1.4.0b1</release>
+    <api>1.4.0b1</api>
+   </version>
+   <stability>
+    <release>beta</release>
+    <api>beta</api>
+   </stability>
+   <date>2016-02-15</date>
+   <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
+   <notes>
+- Add PHP 7.0 support. (Adam)
+- Drop support for PHP &lt; 5.3.
+   </notes>
+  </release>
   <release>
    <version>
     <release>1.3.0</release>
     <api>1.3.0</api>
    </version>
-
    <stability>
     <release>stable</release>
     <api>stable</api>
@@ -136,13 +148,11 @@ OS (for example against Windows Active-Directory via IAS).
 - Fixed bug #65599 (Fix compiling for VC11 x64). (Jan Ehrhardt)
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.3.0b1</release>
     <api>1.3.0b1</api>
    </version>
-
    <stability>
     <release>beta</release>
     <api>beta</api>
@@ -167,7 +177,7 @@ Three new functions have been added to handle these features:
 - radius_get_tagged_attr_tag(string attr)
   This function returns the tag from a tagged attribute.
 - radius_salt_encrypt_attr(resource radius_handle, string attr)
-  This function salt-encrypts the given attribute. This shouldn't normally need
+  This function salt-encrypts the given attribute. This shouldn&apos;t normally need
   to be called manually, but is available for unusual use cases.
 
 Salt encryption is generally achieved through the use of the new
@@ -176,7 +186,6 @@ optional options bitfield and an optional tag value, which will be used to tag
 an attribute if the RADIUS_OPTION_TAGGED option is set.
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.2.7</release>
@@ -197,7 +206,6 @@ with other users encouraged to upgrade when practical.
   VSA length field against the buffer size. (Adam)
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.2.6</release>
@@ -216,7 +224,6 @@ with other users encouraged to upgrade when practical.
   (Adam)
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.2.5</release>
@@ -228,12 +235,11 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2007-03-18</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.2.5
+   <notes>
+- Release 1.2.5
 - amd64 arch fixes
-
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.2.4</release>
@@ -245,12 +251,11 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2003-11-17</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.2.4
+   <notes>
+- Release 1.2.4
 - Forgot including updated radius_init_const.h
-
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.2.3</release>
@@ -262,10 +267,10 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2003-11-04</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.2.3
+   <notes>
+- Release 1.2.3
 - Fixed a typo in radius_init_const.h wich caused RADIUS_ACCT_STATUS_TYPE to be undefined.
 - Re-added Makefile.in
-
    </notes>
   </release>
   <release>
@@ -279,14 +284,13 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2003-07-17</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.2.2 
+   <notes>
+- Release 1.2.2 
 - Changed role for example-files to doc
 - Removed deprecated files
 - Added IPv6 related attributes defined in RFC3162
-
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.2.1</release>
@@ -298,7 +302,8 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2003-05-02</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.2.1   
+   <notes>
+- Release 1.2.1   
 - Change License to BSD
 - BugFix: The MS-CHAPv2 Authenticator-Challenge has 16 Bytes and not 8 Bytes
 - BugFix: build under Solaris
@@ -306,10 +311,8 @@ with other users encouraged to upgrade when practical.
 - Many source-code-style fixes
 - Removed unneeded sources
 - Some cleanup&apos;s
-
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.2</release>
@@ -321,7 +324,8 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2003-01-11</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.2    
+   <notes>
+- Release 1.2    
 - BugFix: a to short challenge was generated sometimes (MS-CHAPv1, MS-CHAPv2)
 - New functions:
     radius_demangle: demangles radius passwords and mppe MS-CHAPv1 Keys
@@ -329,11 +333,9 @@ with other users encouraged to upgrade when practical.
 - Provide examples for radius-accounting
 - Replaced mcrypt-functions with own des-ecb-encryption function
 - Some minor changes in radius-auth.php
-- Added php-script for testing MS-CHAP functions    
-
+- Added php-script for testing MS-CHAP functions
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.1</release>
@@ -345,13 +347,13 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2002-12-22</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.1
+   <notes>
+- Release 1.1
 - Fixed source code style
 - added examples directory
 - added examples for MS-CHAPv1 and MS-CHAPv2
    </notes>
   </release>
-
   <release>
    <version>
     <release>1.0</release>
@@ -363,10 +365,10 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2002-12-17</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Release 1.0
+   <notes>
+- Release 1.0
    </notes>
   </release>
-
   <release>
    <version>
     <release>0.9</release>
@@ -378,10 +380,9 @@ with other users encouraged to upgrade when practical.
    </stability>
    <date>2002-12-11</date>
    <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-   <notes>- Well tested under Linux, FreeBSD and Windows
+   <notes>
+- Well tested under Linux, FreeBSD and Windows
    </notes>
   </release>
-
  </changelog>
 </package>
-<!-- vim: set ts=1 sw=1 et nocin ai: -->

--- a/pecl-compat/compat.h
+++ b/pecl-compat/compat.h
@@ -1,0 +1,110 @@
+/*
+  +----------------------------------------------------------------------+
+  | Compatibility macros for different PHP versions                      |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2015 The PHP Group                                     |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Francois Laupretre <francois@tekwire.net>                    |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef _COMPAT_H
+#define _COMPAT_H
+
+#define PECL_COMPAT_VERSION 1.2
+
+#include <stdio.h>
+#include <assert.h>
+#include <fcntl.h>
+
+#include "php.h"
+#include "zend.h"
+#include "zend_extensions.h"
+#include "zend_API.h"
+
+#define PHP_5_0_X_API_NO                220040412
+#define PHP_5_1_X_API_NO                220051025
+#define PHP_5_2_X_API_NO                220060519
+#define PHP_5_3_X_API_NO                220090626
+#define PHP_5_4_X_API_NO                220100525
+#define PHP_5_5_X_API_NO                220121212
+#define PHP_5_6_X_API_NO                220131226
+
+#if PHP_MAJOR_VERSION >= 7
+#	define PHP_7
+#endif
+
+#ifdef HAVE_CONFIG_H
+#	include "config.h"
+#endif
+
+#if HAVE_STRING_H
+#	include <string.h>
+#endif
+
+#ifdef HAVE_SYS_TYPES_H
+#	include <sys/types.h>
+#endif
+
+#ifdef PHP_WIN32
+#	include "win32/time.h"
+#elif defined(NETWARE)
+#	include <sys/timeval.h>
+#	include <sys/time.h>
+#else
+#	include <sys/time.h>
+#endif
+
+#ifdef HAVE_SYS_RESOURCE_H
+#	include <sys/resource.h>
+#endif
+
+#ifdef HAVE_STDARG_H
+#include <stdarg.h>
+#endif
+
+#ifdef HAVE_STDLIB_H
+#	include <stdlib.h>
+#endif
+
+#ifdef HAVE_UNISTD_H
+#	include <unistd.h>
+#endif
+
+#ifdef HAVE_SYS_STAT_H
+#	include <sys/stat.h>
+#endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1920
+#include <win32/php_stdint.h>
+#else
+#include <inttypes.h>
+#endif
+
+#if ZEND_EXTENSION_API_NO >= PHP_5_6_X_API_NO
+#include "zend_virtual_cwd.h"
+#else
+#include "TSRM/tsrm_virtual_cwd.h"
+#endif
+
+#ifdef PHP_7
+#include "Zend/zend_portability.h"
+#endif
+
+/*-- Include submodules */
+
+#include "src/misc.h"
+#include "src/zend_string.h"
+#include "src/zend_hash.h"
+#include "src/zend_API.h"
+#include "src/zend_resource.h"
+
+#endif /* _COMPAT_H */

--- a/pecl-compat/src/misc.h
+++ b/pecl-compat/src/misc.h
@@ -1,0 +1,253 @@
+/*
+  +----------------------------------------------------------------------+
+  | Compatibility between PHP versions                                   |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2015 The PHP Group                                     |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Francois Laupretre <francois@tekwire.net>                    |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef __PECL_COMPAT_MISC_H
+#define __PECL_COMPAT_MISC_H 1
+
+#ifdef PHP_7
+/*============================================================================*/
+
+typedef zend_string * OPENED_PATH_PTR; /* Type of stream opened_path argument */
+typedef size_t        COMPAT_ARG_SIZE_T; /* Size of string arguments */
+typedef zend_long     COMPAT_ARG_LONG_T; /* Type of long (integer) arguments */
+
+#define compat_zval_ptr_dtor(zp)	zval_ptr_dtor(zp)
+
+#else
+/*== PHP 5 ===================================================================*/
+
+typedef char *    OPENED_PATH_PTR;
+typedef off_t     zend_off_t;
+typedef int       COMPAT_ARG_SIZE_T;
+typedef long      COMPAT_ARG_LONG_T;
+typedef long      zend_long;
+
+#define compat_zval_ptr_dtor(zp)	zval_dtor(zp)
+
+#endif
+/*============================================================================*/
+
+#ifndef MIN
+#	define MIN(a,b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#	define MAX(a,b) (((a) > (b)) ? (a) : (b))
+#endif
+
+/*---------------------------------------------------------------*/
+/* (Taken from pcre/pcrelib/internal.h) */
+/* To cope with SunOS4 and other systems that lack memmove() but have bcopy(),
+define a macro for memmove() if HAVE_MEMMOVE is false, provided that HAVE_BCOPY
+is set. Otherwise, include an emulating function for those systems that have
+neither (there are some non-Unix environments where this is the case). This
+assumes that all calls to memmove are moving strings upwards in store,
+which is the case in this extension. */
+
+#if ! HAVE_MEMMOVE
+#	ifdef memmove
+#		undef  memmove					/* some systems may have a macro */
+#	endif
+#	if HAVE_BCOPY
+#		define memmove(a, b, c) bcopy(b, a, c)
+#	else
+		static void *my_memmove(unsigned char *dest, const unsigned char *src,
+								size_t n)
+		{
+			int i;
+
+			dest += n;
+			src += n;
+			for (i = 0; i < n; ++i)
+				*(--dest) = *(--src);
+		}
+#		define memmove(a, b, c) my_memmove(a, b, c)
+#	endif	/* not HAVE_BCOPY */
+#endif		/* not HAVE_MEMMOVE */
+
+#ifdef _AIX
+#	undef PHP_SHLIB_SUFFIX
+#	define PHP_SHLIB_SUFFIX "a"
+#endif
+
+#ifndef ZVAL_IS_ARRAY
+#define ZVAL_IS_ARRAY(zp)	(Z_TYPE_P((zp))==IS_ARRAY)
+#endif
+
+#ifndef ZVAL_IS_STRING
+#define ZVAL_IS_STRING(zp)	(Z_TYPE_P((zp))==IS_STRING)
+#endif
+
+#ifndef ZVAL_IS_LONG
+#define ZVAL_IS_LONG(zp)	(Z_TYPE_P((zp))==IS_LONG)
+#endif
+
+#ifndef ZVAL_IS_BOOL
+#define ZVAL_IS_BOOL(zp)	(Z_TYPE_P((zp))==IS_BOOL)
+#endif
+
+#ifndef INIT_ZVAL
+#define INIT_ZVAL(z) memset(&z, 0, sizeof(z))
+#endif
+
+#ifndef ZVAL_UNDEF
+#define ZVAL_UNDEF(z) INIT_ZVAL(*(z))
+#endif
+
+#ifndef MAKE_STD_ZVAL
+#define MAKE_STD_ZVAL(zp) { zp = emalloc(sizeof(zval)); INIT_ZVAL(*zp); }
+#endif
+
+#ifndef ALLOC_INIT_ZVAL
+#define ALLOC_INIT_ZVAL(zp) MAKE_STD_ZVAL(zp)
+#endif
+
+#ifndef ZEND_ASSUME
+#if defined(ZEND_WIN32) && !defined(__clang__)
+# define ZEND_ASSUME(c) __assume(c)
+#else
+# define ZEND_ASSUME(c)
+#endif
+#endif
+
+#ifndef ZEND_ASSERT
+#if ZEND_DEBUG
+# define ZEND_ASSERT(c) assert(c)
+#else
+# define ZEND_ASSERT(c) ZEND_ASSUME(c)
+#endif
+#endif
+
+#ifndef EMPTY_SWITCH_DEFAULT_CASE
+/* Only use this macro if you know for sure that all of the switches values
+   are covered by its case statements */
+#if ZEND_DEBUG
+# define EMPTY_SWITCH_DEFAULT_CASE() default: ZEND_ASSERT(0); break;
+#else
+# define EMPTY_SWITCH_DEFAULT_CASE() default: ZEND_ASSUME(0); break;
+#endif
+#endif
+
+#ifndef ZEND_IGNORE_VALUE
+#if defined(__GNUC__) && __GNUC__ >= 4
+# define ZEND_IGNORE_VALUE(x) (({ __typeof__ (x) __x = (x); (void) __x; }))
+#else
+# define ZEND_IGNORE_VALUE(x) ((void) (x))
+#endif
+#endif
+
+#if PHP_API_VERSION >= 20100412
+	typedef size_t PHP_ESCAPE_HTML_ENTITIES_SIZE;
+#else
+	typedef int PHP_ESCAPE_HTML_ENTITIES_SIZE;
+#endif
+
+/* Avoid a warning when compiling stream wrapper declarations for
+   openfile/opendir/url_stat */
+
+#if ZEND_EXTENSION_API_NO >= PHP_5_6_X_API_NO
+#	define COMPAT_STREAM_CONST_DECL const
+#else
+#	define COMPAT_STREAM_CONST_DECL
+#endif
+
+#ifndef ZEND_MODULE_GLOBALS_ACCESSOR
+#	ifdef ZTS
+#		define ZEND_MODULE_GLOBALS_ACCESSOR(module_name, v) \
+			TSRMG(module_name##_globals_id, zend_##module_name##_globals *, v)
+#	else
+#		define ZEND_MODULE_GLOBALS_ACCESSOR(module_name, v) \
+			(module_name##_globals.v)
+#	endif
+#endif
+
+#ifndef ZEND_MODULE_GLOBALS_BULK
+#	ifdef ZTS
+#		define ZEND_MODULE_GLOBALS_BULK(module_name) \
+			((zend_##module_name##_globals *) \
+				(*((void ***) tsrm_ls))[module_name##_globals_id - 1])
+#	else
+#		define ZEND_MODULE_GLOBALS_BULK(module_name) \
+			(&module_name##_globals)
+#	endif
+#endif
+
+#ifndef ZEND_TSRMLS_CACHE_DEFINE
+#	define ZEND_TSRMLS_CACHE_DEFINE()
+#endif
+
+#ifndef ZEND_TSRMLS_CACHE_UPDATE
+#	define ZEND_TSRMLS_CACHE_UPDATE()
+#endif
+
+#ifndef PHP_FE_END
+# define PHP_FE_END { NULL, NULL, NULL }
+#endif
+
+#ifndef ZEND_MOD_END
+	/* for php < 5.3.7 */
+#	define ZEND_MOD_END {NULL, NULL, NULL}
+#endif
+
+/*============================================================================*/
+/* Duplicate a memory buffer */
+/* Supports zero size (allocates 1 byte) */
+
+static zend_always_inline void *_compat_dup(const void *ptr, size_t size, int persistent)
+{
+	char *p;
+
+	if (!ptr) return NULL;
+	if (size) {
+		p = pemalloc(size, persistent);
+		memmove(p, ptr, size);
+	} else {
+		p = pemalloc(1,persistent);
+		(*p) = '\0'; /* Ensures deterministic behavior */
+	}
+
+	return p;
+}
+
+/*---------------------------------------------------------------*/
+/* Duplicate a string and set terminating null.
+   Input string does not have to be null-terminated */
+
+static zend_always_inline void *_compat_dup_str(const void *ptr, size_t size, int persistent)
+{
+	char *p;
+
+	if (!ptr) return NULL;
+
+	p = pemalloc(size + 1, persistent);
+	if (size) memmove(p, ptr, size);
+	p[size] = '\0';
+	return p;
+}
+
+/*-----------------------------------------------------*/
+/* Fatal error - display message and abort process */
+
+static zend_always_inline void compat_unsupported(char *msg)
+{
+	php_error(E_CORE_ERROR, "This feature is not supported in this environment : %s", msg);
+	exit(1);
+}
+
+/*============================================================================*/
+#endif	/* __PECL_COMPAT_MISC_H */

--- a/pecl-compat/src/zend_API.h
+++ b/pecl-compat/src/zend_API.h
@@ -1,0 +1,76 @@
+/*
+  +----------------------------------------------------------------------+
+  | Compatibility macros for different PHP versions                      |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2016 The PHP Group                                     |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Adam Harvey <aharvey@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef _COMPAT_ZEND_API_H
+#define _COMPAT_ZEND_API_H
+
+#ifdef PHP_7
+/*============================================================================*/
+
+#else
+/*== PHP 5 ===================================================================*/
+
+/*
+ * Many string-related macros used to take duplicate parameters, which
+ * specified whether the string should be duplicated or not. In practice,
+ * almost all code used 1, so PHP 7 always duplicates.
+ *
+ * This header redefines the relevant macros to match PHP 7.
+ */
+
+#undef ZVAL_STRING
+#define ZVAL_STRING(z, s) do { \
+		const char *__s = (s); \
+		zval *__z = (z); \
+		Z_STRLEN_P(__z) = strlen(__s); \
+		Z_STRVAL_P(__z) = estrndup(__s, Z_STRLEN_P(__z)); \
+		Z_TYPE_P(__z) = IS_STRING; \
+	} while (0)
+
+#undef ZVAL_STRINGL
+#define ZVAL_STRINGL(z, s, l) do { \
+		const char *__s = (s); \
+		int __l = (l); \
+		zval *__z = (z); \
+		Z_STRLEN_P(__z) = __l; \
+		Z_STRVAL_P(__z) = estrndup(__s, __l); \
+		Z_TYPE_P(__z) = IS_STRING; \
+	} while (0)
+
+#undef RETVAL_STRING
+#define RETVAL_STRING(s)     ZVAL_STRING(return_value, (s))
+
+#undef RETVAL_STRINGL
+#define RETVAL_STRINGL(s, l) ZVAL_STRINGL(return_value, (s), (l))
+
+#undef RETURN_STRING
+#define RETURN_STRING(s)     { RETVAL_STRING(s); return; }
+
+#undef RETURN_STRINGL
+#define RETURN_STRINGL(s, l) { RETVAL_STRINGL(s, l); return; }
+
+#undef add_assoc_string
+#define add_assoc_string(__arg, __key, __str) add_assoc_string_ex(__arg, __key, strlen(__key)+1, __str, 1)
+
+#undef add_assoc_stringl
+#define add_assoc_stringl(__arg, __key, __str, __len) add_assoc_stringl_ex(__arg, __key, strlen(__key)+1, __str, __len, 1)
+
+#endif /* PHP_7 */
+/*============================================================================*/
+
+#endif /* _COMPAT_ZEND_API_H */

--- a/pecl-compat/src/zend_hash.h
+++ b/pecl-compat/src/zend_hash.h
@@ -1,0 +1,384 @@
+/*
+  +----------------------------------------------------------------------+
+  | zend_hash compatibility layer for PHP 5 & 7							 |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2005-2007 The PHP Group								 |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,		 |
+  | that is bundled with this package in the file LICENSE, and is		 |
+  | available through the world-wide-web at the following url:			 |
+  | http://www.php.net/license/3_01.txt.								 |
+  | If you did not receive a copy of the PHP license and are unable to	 |
+  | obtain it through the world-wide-web, please send a note to			 |
+  | license@php.net so we can mail you a copy immediately.				 |
+  +----------------------------------------------------------------------+
+  | Author: Francois Laupretre <francois@tekwire.net>					 |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef _COMPAT_ZEND_HASH_H
+#define _COMPAT_ZEND_HASH_H
+
+#include "zend_hash.h"
+
+#ifdef PHP_7
+/*============================================================================*/
+
+#define compat_zend_hash_exists(ht, key) zend_hash_exists(ht, key)
+
+#define compat_zend_hash_str_exists(ht, str, len) zend_hash_str_exists(ht, str, len)
+
+#define COMPAT_HASH_PTR(_zp) (&(Z_PTR_P(_zp)))
+
+/*---------*/
+/* Changes from original version:
+	- If numeric key, returned (zend_string *) is set to NULL.
+	- If non null, returned zend_string must be released.
+*/
+static zend_always_inline int compat_zend_hash_get_current_key_ex(const HashTable *ht
+	, zend_string **str_index, zend_ulong *num_index, HashPosition *pos)
+{
+	int status;
+
+	if (str_index) (*str_index) = NULL;
+	status = zend_hash_get_current_key_ex(ht, str_index, num_index, pos);
+	if (*str_index) zend_string_addref(*str_index);
+	return status;
+}
+
+/*---------*/
+/* Added - This function is equivalent to the PHP 5 version of
+   zend_hash_get_current_key_ex() */
+
+static zend_always_inline int compat_zend_hash_str_get_current_key_ex(const HashTable *ht
+	, char **str_index, size_t *str_length, zend_ulong *num_index
+	, zend_bool duplicate, HashPosition *pos)
+{
+	int status;
+	zend_string *zp;
+
+	zp = NULL;
+	status = zend_hash_get_current_key_ex(ht, &zp, num_index, pos);
+	if (zp) {
+		if (duplicate) {
+			(*str_index) = estrndup(ZSTR_VAL(zp), ZSTR_LEN(zp));
+		} else {
+			(*str_index) = ZSTR_VAL(zp);
+		}
+		(*str_length) = ZSTR_LEN(zp);
+	}
+	return status;
+}	
+
+/*---------*/
+
+static zend_always_inline void *compat_zend_hash_get_current_data_ptr_ex(HashTable *ht
+	, HashPosition *pos)
+{
+	zval *zp;
+
+	zp = zend_hash_get_current_data_ex(ht, pos);
+	return Z_PTR_P(zp);
+}
+
+#define compat_zend_hash_get_current_data_ptr(ht) \
+	compat_zend_hash_get_current_data_ptr_ex(ht, &(ht)->nInternalPointer)
+
+/*---------*/
+
+static zend_always_inline void *compat_zend_hash_get_current_data_ex(HashTable *ht
+	, HashPosition *pos)
+{
+	return (void *)zend_hash_get_current_data_ex(ht, pos);
+}
+
+#define compat_zend_hash_get_current_data(ht) \
+	compat_zend_hash_get_current_data_ex(ht, &(ht)->nInternalPointer)
+
+#define compat_zend_hash_get_current_zval_ex(ht, pos) \
+		(zval *)compat_zend_hash_get_current_data_ex(ht, pos)
+
+#define compat_zend_hash_get_current_zval(ht) \
+	compat_zend_hash_get_current_zval_ex(ht, &(ht)->nInternalPointer)
+
+#else
+/*= PHP 5 ====================================================================*/
+
+#ifndef HASH_KEY_NON_EXISTENT
+#define HASH_KEY_NON_EXISTENT HASH_KEY_NON_EXISTANT
+#endif
+
+#define COMPAT_HASH_PTR(_zp) (_zp)
+
+/*------------------------------------------------*/
+
+static zend_always_inline void *zend_hash_add_ptr(HashTable *ht
+	, zend_string *key, void *pData)
+{
+	int status;
+
+	status = zend_hash_quick_add(ht, ZSTR_VAL(key), (uint)(ZSTR_LEN(key) + 1)
+		, (ulong)ZSTR_HASH(key), &pData, sizeof(void *), NULL);
+	return (status == SUCCESS ? pData : NULL);
+}
+
+#define zend_hash_add_new_ptr(ht, key, pData) zend_hash_add_ptr(ht, key, pData)
+
+#define zend_hash_add_mem(ht, key, pData, size) \
+	zend_hash_add_ptr(ht, key, _compat_dup(pData, size, ht->persistent))
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_str_add_ptr(HashTable *ht
+	, const char *str, size_t len, void *pData)
+{
+	int status;
+	char *strn = _compat_dup_str(str, len, 0);
+
+	status = zend_hash_add(ht, strn, len + 1, &pData, sizeof(void *), NULL);
+	efree(strn);
+	return (status == SUCCESS ? pData : NULL);
+}
+
+#define zend_hash_str_add_new_ptr(ht, str, len, pData) zend_hash_str_add_ptr(ht, str, len, pData)
+
+#define zend_hash_str_add_mem(ht, str, len, pData, size) \
+	zend_hash_str_add_ptr(ht, str, len, _compat_dup(pData, size, ht->persistent))
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_index_add_ptr(HashTable *ht
+	, zend_ulong h, void *pData)
+{
+	int status;
+
+	status = zend_hash_index_update(ht, (ulong)h, &pData, sizeof(void *), NULL);
+	return (status == SUCCESS ? pData : NULL);
+}
+
+#define zend_hash_index_add_new_ptr(ht, h, pData) \
+	zend_hash_index_add_ptr(ht, h, pData)
+
+#define zend_hash_index_add_mem(ht, h, pData, size) \
+	zend_hash_index_add_ptr(ht, h, _compat_dup(pData, size, ht->persistent))
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_next_index_insert_ptr(HashTable *ht
+	, void *pData)
+{
+	int status;
+
+	status = zend_hash_next_index_insert(ht, &pData, sizeof(void *), NULL);
+	return (status == SUCCESS ? pData : NULL);
+}
+
+#define zend_hash_next_index_insert_mem(ht, pData, size) \
+	zend_hash_next_index_insert_ptr(ht, _compat_dup(pData, size, ht->persistent))
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_update_ptr(HashTable *ht
+	, zend_string *key, void *pData)
+{
+	int status;
+
+	status = zend_hash_quick_update(ht, ZSTR_VAL(key), (uint)(ZSTR_LEN(key) + 1)
+		, (ulong)ZSTR_HASH(key), &pData, sizeof(void *), NULL);
+	return (status == SUCCESS ? pData : NULL);
+}
+
+#define zend_hash_update_mem(ht, key, pData, size) \
+	zend_hash_update_ptr(ht, key, _compat_dup(pData, size, ht->persistent))
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_str_update_ptr(HashTable *ht
+	, const char *str, size_t len, void *pData)
+{
+	int status;
+	char *strn = _compat_dup_str(str, len, 0);
+
+	status = zend_hash_update(ht, strn, len + 1, &pData, sizeof(void *), NULL);
+	efree(strn);
+	return (status == SUCCESS ? pData : NULL);
+}
+
+#define zend_hash_str_upate_mem(ht, str, len, pData, size) \
+	zend_hash_str_update_ptr(ht, str, len, _compat_dup(pData, size, ht->persistent))
+
+#define zend_hash_index_update_ptr(ht, h, pData) \
+	zend_hash_index_add_ptr(ht, h, pData)
+
+#define zend_hash_index_update_mem(ht, h, pData, size) \
+	zend_hash_index_add_mem(ht, h, pData, size)
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_find_ptr(const HashTable *ht
+	, zend_string *key)
+{
+	int status;
+	void **p;
+
+	status = zend_hash_quick_find(ht, ZSTR_VAL(key), (uint)(ZSTR_LEN(key) + 1)
+		, (ulong)ZSTR_HASH(key), (void **)(&p));
+	return (status == SUCCESS ? (*p) : NULL);
+}
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_str_find_ptr(const HashTable *ht
+	, const char *str, size_t len)
+{
+	int status;
+	void **p;
+	char *strn = _compat_dup_str(str, len, 0);
+
+	status = zend_hash_find(ht, strn, len + 1, (void **)(&p));
+	efree(strn);
+	return (status == SUCCESS ? (*p) : NULL);
+}
+
+/*---------*/
+
+static zend_always_inline void *zend_hash_index_find_ptr(const HashTable *ht
+	, zend_ulong h)
+{
+	int status;
+	void **p;
+
+	status = zend_hash_index_find(ht, h, (void **)(&p));
+	return (status == SUCCESS ? (*p) : NULL);
+}
+
+/*---------*/
+
+static zend_always_inline zend_bool compat_zend_hash_exists(const HashTable *ht
+	, zend_string *key)
+{
+	return zend_hash_quick_exists(ht, ZSTR_VAL(key), (uint)(ZSTR_LEN(key) + 1)
+		, (ulong)ZSTR_HASH(key));
+}
+
+/*---------*/
+
+static zend_always_inline zend_bool compat_zend_hash_str_exists(const HashTable *ht
+	, const char *str, size_t len)
+{
+	zend_bool status;
+	char *strn = _compat_dup_str(str, len, 0);
+
+	status = zend_hash_exists(ht, strn, (uint)(len + 1));
+	efree(strn);
+	return status;
+}
+
+/*---------*/
+/* Changes from original version:
+	- Returns a zend_string
+	- If key is a string, returned zend_string must be released.
+*/
+static zend_always_inline int compat_zend_hash_get_current_key_ex(const HashTable *ht
+	, zend_string **str_index, zend_ulong *num_index, HashPosition *pos)
+{
+	int status;
+	char *str;
+	uint str_length;
+	ulong num;
+
+	status = zend_hash_get_current_key_ex(ht, &str, &str_length, &num, 0, pos);
+	if (status == HASH_KEY_IS_STRING) {
+		(*str_index) = zend_string_init(str, str_length - 1, ht->persistent);
+	} else if (status == HASH_KEY_IS_LONG) {
+		(*num_index) = (zend_ulong)num;
+	}
+	return status;
+}
+
+/*---------*/
+/* Diff with original :
+	- Type casts
+	- Return string length, without trailing null */
+
+static zend_always_inline int compat_zend_hash_str_get_current_key_ex(const HashTable *ht
+	, char **str_index, size_t *str_length, zend_ulong *num_index
+	, zend_bool duplicate, HashPosition *pos)
+{
+	int status;
+	uint length;
+	ulong num;
+
+	status = zend_hash_get_current_key_ex(ht, str_index, &length, &num, duplicate, pos);
+	if (status == HASH_KEY_IS_STRING) {
+		(*str_length) = (size_t)(length - 1);
+	} else if (status == HASH_KEY_IS_LONG) {
+		(*num_index) = (zend_ulong)num;
+	}
+	return status;
+}
+
+/*---------*/
+
+static zend_always_inline void *compat_zend_hash_get_current_data_ptr_ex(HashTable *ht
+	, HashPosition *pos)
+{
+	int status;
+	void **p;
+
+	status = zend_hash_get_current_data_ex(ht, (void **)(&p), pos);
+	return ((status == SUCCESS) ? (*p) : NULL);
+}
+
+#define compat_zend_hash_get_current_data_ptr(ht) \
+	compat_zend_hash_get_current_data_ptr_ex(ht, NULL)
+
+/*---------*/
+
+static zend_always_inline void *compat_zend_hash_get_current_data_ex(HashTable *ht
+	, HashPosition *pos)
+{
+	int status;
+	void **p;
+
+	status = zend_hash_get_current_data_ex(ht, (void **)(&p), pos);
+	return ((status == SUCCESS) ? p : NULL);
+}
+
+#define compat_zend_hash_get_current_data(ht) \
+	compat_zend_hash_get_current_data_ex(ht, NULL)
+
+#define compat_zend_hash_get_current_zval_ex(ht, pos) \
+		*((zval **)compat_zend_hash_get_current_data_ex(ht, pos))
+
+#define compat_zend_hash_get_current_zval(ht) \
+	compat_zend_hash_get_current_zval_ex(ht, NULL)
+
+/*------------------------------------------------------------*/
+
+#define ZEND_HASH_FOREACH(_ht, indirect) do { \
+	HashPosition _pos; \
+	for (zend_hash_internal_pointer_reset_ex(_ht, &_pos) \
+		;;zend_hash_move_forward_ex(_ht, &_pos)) { \
+		if (zend_hash_has_more_elements_ex(_ht, &_pos) != SUCCESS) break;
+
+#define ZEND_HASH_FOREACH_END() \
+	} \
+} while (0)
+
+#define ZEND_HASH_FOREACH_PTR(_ht, _ptr) \
+	ZEND_HASH_FOREACH(_ht, 0); \
+	_ptr = compat_zend_hash_get_current_data_ptr_ex(_ht, &_pos);
+
+#define ZEND_HASH_FOREACH_NUM_KEY(_ht, _h) \
+	ZEND_HASH_FOREACH(_ht, 0); \
+	compat_zend_hash_get_current_key_ex(_ht, NULL, &_h, &_pos);
+
+#define ZEND_HASH_FOREACH_NUM_KEY_PTR(_ht, _h, _ptr) \
+	ZEND_HASH_FOREACH(_ht, 0); \
+	_ptr = compat_zend_hash_get_current_data_ptr_ex(_ht, &_pos); \
+	compat_zend_hash_get_current_key_ex(_ht, NULL, &_h, &_pos);
+
+/*============================================================================*/
+#endif /* PHP_7 */
+#endif /* _COMPAT_ZEND_HASH_H */

--- a/pecl-compat/src/zend_resource.h
+++ b/pecl-compat/src/zend_resource.h
@@ -1,0 +1,140 @@
+/*
+  +----------------------------------------------------------------------+
+  | Compatibility macros for different PHP versions                      |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2016 The PHP Group                                     |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Adam Harvey <aharvey@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef _COMPAT_ZEND_RESOURCE_H
+#define _COMPAT_ZEND_RESOURCE_H
+
+/*
+ * The PHP 5 and PHP 7 resource APIs use the same function names for mutually
+ * incompatible functions, which is unfortunate. A simple version of the PHP 5
+ * macro API can be implemented on top of the PHP 7 API, but not vice versa
+ * (since, for example, zend_register_resource() in PHP 5 also sets the zval,
+ * which is a separate action in PHP 7).
+ *
+ * Instead of using preprocessor trickery to try to mangle things into a sane
+ * API, I've implemented a minimal API that supports basic resource handling
+ * and delegates appropriately on both versions.
+ *
+ * Destructors should be registered using the normal
+ * zend_register_list_destructors() or zend_register_list_destructors_ex()
+ * functions. The destructor function should take a "zend_resource *" (there is
+ * an appropriate typedef in the PHP 5 section to make this work); as only a
+ * subset of fields are available across PHP versions, this should be treated
+ * as this struct in effect:
+ *
+ * typedef struct {
+ *   void *ptr;
+ *   int   type;
+ * } zend_resource;
+ *
+ * Accessing other fields will likely result in compilation errors and/or
+ * segfaults.
+ */
+
+/**
+ * Deletes the resource.
+ *
+ * On PHP 5, this is equivalent to zend_list_delete(Z_LVAL_P(zv)).
+ * On PHP 7, this is equivalent to zend_list_close(Z_RES_P(zv)).
+ *
+ * @param zv The IS_RESOURCE zval to delete.
+ */
+static void compat_zend_delete_resource(const zval *zv TSRMLS_DC);
+
+/**
+ * Fetches the resource.
+ *
+ * This API does not support the default ID that's possible with the PHP 5
+ * zend_fetch_resource() API, and will always set that value to -1.
+ *
+ * @param zv             The IS_RESOURCE zval to fetch.
+ * @param rsrc_type_name The type name to use in error messages.
+ * @param rsrc_type      The resource type ID.
+ * @return A void pointer to the resource, which needs to be typecast, or NULL
+ *         on error.
+ */
+static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type TSRMLS_DC);
+
+/**
+ * Registers a new resource.
+ *
+ * @param zv        The zval to set to IS_RESOURCE with the new resource value.
+ * @param ptr       A void pointer to the resource.
+ * @param rsrc_type The resource type ID.
+ */
+static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type TSRMLS_DC);
+
+#ifdef PHP_7
+/*============================================================================*/
+
+static void compat_zend_delete_resource(const zval *zv TSRMLS_DC)
+{
+	if (IS_RESOURCE != Z_TYPE_P(zv)) {
+		return;
+	}
+
+	zend_list_close(Z_RES_P(zv));
+}
+
+static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type TSRMLS_DC)
+{
+	if (IS_RESOURCE != Z_TYPE_P(zv)) {
+		return NULL;
+	}
+
+	return zend_fetch_resource(Z_RES_P(zv), rsrc_type_name, rsrc_type);
+}
+
+static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type TSRMLS_DC)
+{
+	ZVAL_RES(zv, zend_register_resource(ptr, rsrc_type));
+}
+
+#else
+/*== PHP 5 ===================================================================*/
+
+/* Used for destructors. */
+typedef zend_rsrc_list_entry zend_resource;
+
+static void compat_zend_delete_resource(const zval *zv TSRMLS_DC)
+{
+	if (IS_RESOURCE != Z_TYPE_P(zv)) {
+		return;
+	}
+
+	zend_list_delete(Z_LVAL_P(zv));
+}
+
+static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type TSRMLS_DC)
+{
+#if ZEND_MODULE_API_NO >= 20100412
+	return zend_fetch_resource(&zv TSRMLS_CC, -1, rsrc_type_name, NULL, 1, rsrc_type);
+#else
+	return zend_fetch_resource(&zv TSRMLS_CC, -1, (char *)rsrc_type_name, NULL, 1, rsrc_type);
+#endif
+}
+
+static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type TSRMLS_DC)
+{
+	ZEND_REGISTER_RESOURCE(zv, ptr, rsrc_type);
+}
+
+#endif /* PHP_7 */
+/*============================================================================*/
+
+#endif /* _COMPAT_ZEND_RESOURCE_H */

--- a/pecl-compat/src/zend_resource.h
+++ b/pecl-compat/src/zend_resource.h
@@ -54,7 +54,7 @@
  *
  * @param zv The IS_RESOURCE zval to delete.
  */
-static void compat_zend_delete_resource(const zval *zv TSRMLS_DC);
+static void compat_zend_delete_resource(const zval *zv);
 
 /**
  * Fetches the resource.
@@ -68,7 +68,7 @@ static void compat_zend_delete_resource(const zval *zv TSRMLS_DC);
  * @return A void pointer to the resource, which needs to be typecast, or NULL
  *         on error.
  */
-static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type TSRMLS_DC);
+static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type);
 
 /**
  * Registers a new resource.
@@ -77,12 +77,12 @@ static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, in
  * @param ptr       A void pointer to the resource.
  * @param rsrc_type The resource type ID.
  */
-static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type TSRMLS_DC);
+static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type);
 
 #ifdef PHP_7
 /*============================================================================*/
 
-static void compat_zend_delete_resource(const zval *zv TSRMLS_DC)
+static void compat_zend_delete_resource(const zval *zv)
 {
 	if (IS_RESOURCE != Z_TYPE_P(zv)) {
 		return;
@@ -91,7 +91,7 @@ static void compat_zend_delete_resource(const zval *zv TSRMLS_DC)
 	zend_list_close(Z_RES_P(zv));
 }
 
-static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type TSRMLS_DC)
+static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type)
 {
 	if (IS_RESOURCE != Z_TYPE_P(zv)) {
 		return NULL;
@@ -100,7 +100,7 @@ static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, in
 	return zend_fetch_resource(Z_RES_P(zv), rsrc_type_name, rsrc_type);
 }
 
-static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type TSRMLS_DC)
+static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type)
 {
 	ZVAL_RES(zv, zend_register_resource(ptr, rsrc_type));
 }
@@ -111,7 +111,7 @@ static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type TSR
 /* Used for destructors. */
 typedef zend_rsrc_list_entry zend_resource;
 
-static void compat_zend_delete_resource(const zval *zv TSRMLS_DC)
+static void compat_zend_delete_resource(const zval *zv)
 {
 	if (IS_RESOURCE != Z_TYPE_P(zv)) {
 		return;
@@ -120,16 +120,16 @@ static void compat_zend_delete_resource(const zval *zv TSRMLS_DC)
 	zend_list_delete(Z_LVAL_P(zv));
 }
 
-static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type TSRMLS_DC)
+static void *compat_zend_fetch_resource(zval *zv, const char *rsrc_type_name, int rsrc_type)
 {
 #if ZEND_MODULE_API_NO >= 20100412
-	return zend_fetch_resource(&zv TSRMLS_CC, -1, rsrc_type_name, NULL, 1, rsrc_type);
+	return zend_fetch_resource(&zv, -1, rsrc_type_name, NULL, 1, rsrc_type);
 #else
-	return zend_fetch_resource(&zv TSRMLS_CC, -1, (char *)rsrc_type_name, NULL, 1, rsrc_type);
+	return zend_fetch_resource(&zv, -1, (char *)rsrc_type_name, NULL, 1, rsrc_type);
 #endif
 }
 
-static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type TSRMLS_DC)
+static void compat_zend_register_resource(zval *zv, void *ptr, int rsrc_type)
 {
 	ZEND_REGISTER_RESOURCE(zv, ptr, rsrc_type);
 }

--- a/pecl-compat/src/zend_string.h
+++ b/pecl-compat/src/zend_string.h
@@ -1,0 +1,283 @@
+/*
+  +----------------------------------------------------------------------+
+  | zend_string compatibility layer for PHP 5 & 7                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2005-2007 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Francois Laupretre <francois@tekwire.net>                    |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef _COMPAT_ZEND_STRING_H
+#define _COMPAT_ZEND_STRING_H
+
+#ifdef PHP_7
+/*============================================================================*/
+#include "zend_string.h"
+
+#ifndef ZSTR_IS_PERSISTENT
+#	define ZSTR_IS_PERSISTENT(s) (GC_FLAGS(s) & IS_STR_PERSISTENT)
+#endif
+
+#else
+/*============================================================================*/
+/*---- zend_string for PHP 5 ----*/
+
+struct _zend_string {
+		int			persistent;
+		int			hash_is_set; /* needed because computed hash may be null */
+        zend_ulong	h; /* hash value */
+		uint32_t	refcount;
+        size_t		len;
+        char		val[1];
+};
+
+typedef struct _zend_string zend_string;
+
+/* Shortcuts */
+
+#define ZSTR_VAL(zstr)  (zstr)->val
+#define ZSTR_LEN(zstr)  (zstr)->len
+#define ZSTR_H(zstr)    (zstr)->h
+#define ZSTR_HASH(zstr) zend_string_hash_val(zstr)
+
+#define _ZSTR_HEADER_SIZE XtOffsetOf(zend_string, val)
+#define _ZSTR_STRUCT_SIZE(len) (_ZSTR_HEADER_SIZE + len + 1)
+
+#define ZSTR_IS_PERSISTENT(s) (s->persistent)
+
+/*---------*/
+
+static zend_always_inline uint32_t zend_string_refcount(zend_string *s)
+{
+	return (s->refcount);
+}
+
+/*---------*/
+
+static zend_always_inline uint32_t zend_string_addref(zend_string *s)
+{
+	return ++(s->refcount);
+}
+
+/*---------*/
+
+static zend_always_inline uint32_t zend_string_delref(zend_string *s)
+{
+	return --(s->refcount);
+}
+
+/*---------*/
+
+static zend_always_inline zend_ulong zend_string_hash_val(zend_string *s)
+{
+	char c, *p;
+
+	if (! s->hash_is_set) {
+		/* Compute with terminating null but preserve string */
+		p = &(ZSTR_VAL(s)[ZSTR_LEN(s)]);
+		c = (*p);
+		(*p) = '\0';
+		ZSTR_H(s) = zend_get_hash_value(ZSTR_VAL(s), ZSTR_LEN(s)+1);
+		(*p) = c;
+		s->hash_is_set = 1;
+	}
+	return ZSTR_H(s);
+}
+
+/*---------*/
+
+static zend_always_inline void zend_string_forget_hash_val(zend_string *s)
+{
+	s->hash_is_set = 0;
+	ZSTR_H(s) = 0; /* Security */
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_alloc(size_t len, int persistent)
+{
+	zend_string *ret = (zend_string *)pemalloc(ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), persistent);
+	ret->persistent = persistent;
+	zend_string_forget_hash_val(ret);
+	ret->refcount = 1;
+	ZSTR_LEN(ret) = len;
+	return ret;
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_safe_alloc(size_t n
+	, size_t m, size_t l, int persistent)
+{
+	zend_string *ret = (zend_string *)safe_pemalloc(n, m, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(l)), persistent);
+	ret->persistent = persistent;
+	zend_string_forget_hash_val(ret);
+	ret->refcount = 1;
+	ZSTR_LEN(ret) = l;
+	return ret;
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_init(const char *str, size_t len, int persistent)
+{
+	zend_string *ret = zend_string_alloc(len, persistent);
+
+	memcpy(ZSTR_VAL(ret), str, len);
+	ZSTR_VAL(ret)[len] = '\0';
+	return ret;
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_dup(zend_string *s, int persistent)
+{
+	zend_string *target;
+
+	target = zend_string_init(ZSTR_VAL(s), ZSTR_LEN(s), persistent);
+	if (s->hash_is_set) {
+		ZSTR_H(target) = ZSTR_H(s);
+		target->hash_is_set = 1;
+	}
+
+	return target;
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_realloc(zend_string *s
+	, size_t len, int persistent)
+{
+	zend_string *ret;
+
+	if (EXPECTED(s->refcount == 1)) {
+		ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), persistent);
+		ZSTR_LEN(ret) = len;
+		zend_string_forget_hash_val(ret);
+		return ret;
+	}
+
+	zend_string_delref(s);
+    ret = zend_string_alloc(len, persistent);
+    memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), MIN(len, ZSTR_LEN(s)) + 1);
+
+	return ret;
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_extend(zend_string *s
+	, size_t len, int persistent)
+{
+    zend_string *ret;
+
+    ZEND_ASSERT(len >= ZSTR_LEN(s));
+
+	if (EXPECTED(s->refcount == 1)) {
+		ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), persistent);
+		ZSTR_LEN(ret) = len;
+		zend_string_forget_hash_val(ret);
+		return ret;
+	}
+
+	zend_string_delref(s);
+    ret = zend_string_alloc(len, persistent);
+    memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), ZSTR_LEN(s) + 1);
+
+    return ret;
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_truncate(zend_string *s
+	, size_t len, int persistent)
+{
+    zend_string *ret;
+
+    ZEND_ASSERT(len <= ZSTR_LEN(s));
+
+	if (EXPECTED(s->refcount == 1)) {
+		ret = (zend_string *)perealloc(s, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), persistent);
+		ZSTR_LEN(ret) = len;
+		zend_string_forget_hash_val(ret);
+		return ret;
+	}
+
+	zend_string_delref(s);
+    ret = zend_string_alloc(len, persistent);
+    memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), len + 1);
+
+    return ret;
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_safe_realloc(zend_string *s
+	, size_t n, size_t m, size_t l, int persistent)
+{
+    zend_string *ret;
+
+	if (EXPECTED(s->refcount == 1)) {
+		ret = (zend_string *)safe_perealloc(s, n, m, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(l)), persistent);
+		ZSTR_LEN(ret) = (n * m) + l;
+		zend_string_forget_hash_val(ret);
+		return ret;
+	}
+
+	zend_string_delref(s);
+	ret = zend_string_safe_alloc(n, m, l, persistent);
+    memcpy(ZSTR_VAL(ret), ZSTR_VAL(s), MIN((n * m) + l, ZSTR_LEN(s)) + 1);
+    return ret;
+}
+
+/*---------*/
+
+static zend_always_inline void zend_string_free(zend_string *s)
+{
+	if (s) {
+		pefree(s, s->persistent);
+	}
+}
+
+
+/*---------*/
+
+static zend_always_inline void zend_string_release(zend_string *s)
+{
+	if (s) {
+		s->refcount--;
+		if (s->refcount == 0) {
+			zend_string_free(s);
+		}
+	}
+}
+
+/*---------*/
+
+static zend_always_inline zend_string *zend_string_copy(zend_string *s)
+{
+	zend_string_addref(s);
+	return (s);
+}
+
+/*---------*/
+
+static zend_always_inline zend_bool zend_string_equals(zend_string *s1, zend_string *s2)
+{
+	return s1 == s2 || (s1->len == s2->len && !memcmp(s1->val, s2->val, s1->len));
+}
+
+#define zend_string_equals_literal(str, literal) \
+	((str)->len == sizeof(literal)-1 && !memcmp((str)->val, literal, sizeof(literal) - 1))
+
+#endif /* PHP_7 */
+#endif /* _COMPAT_ZEND_STRING_H */

--- a/php_radius.h
+++ b/php_radius.h
@@ -39,7 +39,7 @@ any other GPL-like (LGPL, GPL2) License.
 
 #define phpext_radius_ptr &radius_module_entry
 
-#define PHP_RADIUS_VERSION "1.3.0"
+#define PHP_RADIUS_VERSION "1.4.0b1"
 
 #ifdef PHP_WIN32
 #define PHP_RADIUS_API __declspec(dllexport)
@@ -52,11 +52,6 @@ any other GPL-like (LGPL, GPL2) License.
 #endif
 
 extern zend_module_entry radius_module_entry;
-
-typedef struct {
-	int id;
-	struct rad_handle *radh;
-} radius_descriptor;
 
 PHP_MINIT_FUNCTION(radius);
 PHP_MSHUTDOWN_FUNCTION(radius);

--- a/radius.c
+++ b/radius.c
@@ -51,12 +51,12 @@ any other GPL-like (LGPL, GPL2) License.
 
 #include "pecl-compat/compat.h"
 
-void _radius_close(zend_resource *res TSRMLS_DC);
+void _radius_close(zend_resource *res);
 
 static int _init_options(struct rad_attr_options *out, int options, int tag);
 
 #define RADIUS_FETCH_RESOURCE(radh, zv) \
-	radh = (struct rad_handle *)compat_zend_fetch_resource(zv, "rad_handle", le_radius TSRMLS_CC); \
+	radh = (struct rad_handle *)compat_zend_fetch_resource(zv, "rad_handle", le_radius); \
 	if (!radh) { \
 		RETURN_FALSE; \
 	}
@@ -325,7 +325,7 @@ PHP_FUNCTION(radius_auth_open)
 	struct rad_handle *radh = rad_auth_open();
 
 	if (radh != NULL) {
-		compat_zend_register_resource(return_value, radh, le_radius TSRMLS_CC);
+		compat_zend_register_resource(return_value, radh, le_radius);
 	} else {
 		RETURN_FALSE;
 	}
@@ -338,7 +338,7 @@ PHP_FUNCTION(radius_acct_open)
 	struct rad_handle *radh = rad_acct_open();
 
 	if (radh != NULL) {
-		compat_zend_register_resource(return_value, radh, le_radius TSRMLS_CC);
+		compat_zend_register_resource(return_value, radh, le_radius);
 	} else {
 		RETURN_FALSE;
 	}
@@ -351,13 +351,13 @@ PHP_FUNCTION(radius_close)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &z_radh) == FAILURE) {
 		return;
 	}
 
 	/* Fetch the resource to verify it. */
 	RADIUS_FETCH_RESOURCE(radh, z_radh);
-	compat_zend_delete_resource(z_radh TSRMLS_CC);
+	compat_zend_delete_resource(z_radh);
 	RETURN_TRUE;
 }
 /* }}} */
@@ -369,7 +369,7 @@ PHP_FUNCTION(radius_strerror)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &z_radh) == FAILURE) {
 		return;
 	}
 
@@ -387,7 +387,7 @@ PHP_FUNCTION(radius_config)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &z_radh, &filename, &filename_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &z_radh, &filename, &filename_len) == FAILURE) {
 		return;
 	}
 
@@ -410,7 +410,7 @@ PHP_FUNCTION(radius_add_server)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rslsll", &z_radh,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rslsll", &z_radh,
 		&hostname, &hostname_len,
 		&port,
 		&secret, &secret_len,
@@ -435,7 +435,7 @@ PHP_FUNCTION(radius_create_request)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &z_radh, &code) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &z_radh, &code) == FAILURE) {
 		return;
 	}
 
@@ -459,7 +459,7 @@ PHP_FUNCTION(radius_put_string)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rls|ll", &z_radh, &type, &str, &str_len, &options, &tag)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rls|ll", &z_radh, &type, &str, &str_len, &options, &tag)
 		== FAILURE) {
 		return;
 	}
@@ -484,7 +484,7 @@ PHP_FUNCTION(radius_put_int)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rll|ll", &z_radh, &type, &val, &options, &tag)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rll|ll", &z_radh, &type, &val, &options, &tag)
 		== FAILURE) {
 		return;
 	}
@@ -511,7 +511,7 @@ PHP_FUNCTION(radius_put_attr)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rls|ll", &z_radh, &type, &data, &len, &options, &tag)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rls|ll", &z_radh, &type, &data, &len, &options, &tag)
 		== FAILURE) {
 		return;
 	}
@@ -540,7 +540,7 @@ PHP_FUNCTION(radius_put_addr)
 	zval *z_radh;
 	struct in_addr intern_addr;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rls|ll", &z_radh, &type, &addr, &addrlen, &options, &tag)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rls|ll", &z_radh, &type, &addr, &addrlen, &options, &tag)
 		== FAILURE) {
 		return;
 	}
@@ -572,7 +572,7 @@ PHP_FUNCTION(radius_put_vendor_string)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlls|ll", &z_radh, &vendor, &type, &str, &str_len, &options, &tag)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rlls|ll", &z_radh, &vendor, &type, &str, &str_len, &options, &tag)
 		== FAILURE) {
 		return;
 	}
@@ -597,7 +597,7 @@ PHP_FUNCTION(radius_put_vendor_int)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlll|ll", &z_radh, &vendor, &type, &val, &options, &tag)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rlll|ll", &z_radh, &vendor, &type, &val, &options, &tag)
 		== FAILURE) {
 		return;
 	}
@@ -624,7 +624,7 @@ PHP_FUNCTION(radius_put_vendor_attr)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlls|ll", &z_radh, &vendor, &type,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rlls|ll", &z_radh, &vendor, &type,
 		&data, &len, &options, &tag) == FAILURE) {
 		return;
 	}
@@ -652,7 +652,7 @@ PHP_FUNCTION(radius_put_vendor_addr)
 	zval *z_radh;
 	struct in_addr intern_addr;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlls|ll", &z_radh, &vendor,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rlls|ll", &z_radh, &vendor,
 		&type, &addr, &addrlen, &options, &tag) == FAILURE) {
 		return;
 	}
@@ -681,7 +681,7 @@ PHP_FUNCTION(radius_send_request)
 	zval *z_radh;
 	int res;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &z_radh)
 		== FAILURE) {
 		return;
 	}
@@ -706,7 +706,7 @@ PHP_FUNCTION(radius_get_attr)
 	size_t len;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &z_radh) == FAILURE) {
 		return;
 	}
 
@@ -734,7 +734,7 @@ PHP_FUNCTION(radius_get_tagged_attr_data)
 	const char *attr;
 	COMPAT_ARG_SIZE_T len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &attr, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &attr, &len) == FAILURE) {
 		return;
 	}
 
@@ -755,7 +755,7 @@ PHP_FUNCTION(radius_get_tagged_attr_tag)
 	const char *attr;
 	COMPAT_ARG_SIZE_T len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &attr, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &attr, &len) == FAILURE) {
 		return;
 	}
 
@@ -777,7 +777,7 @@ PHP_FUNCTION(radius_get_vendor_attr)
 	unsigned char type;
 	size_t data_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &raw, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &raw, &len) == FAILURE) {
 		return;
 	}
 
@@ -802,7 +802,7 @@ PHP_FUNCTION(radius_cvt_addr)
 	COMPAT_ARG_SIZE_T len;
 	struct in_addr addr;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &data, &len) == FAILURE) {
 		return;
 	}
 
@@ -819,7 +819,7 @@ PHP_FUNCTION(radius_cvt_int)
 	COMPAT_ARG_SIZE_T len;
 	int val;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &len)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &data, &len)
 		== FAILURE) {
 		return;
 	}
@@ -836,7 +836,7 @@ PHP_FUNCTION(radius_cvt_string)
 	char *val;
 	COMPAT_ARG_SIZE_T len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &len)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &data, &len)
 		== FAILURE) {
 		return;
 	}
@@ -858,7 +858,7 @@ PHP_FUNCTION(radius_salt_encrypt_attr)
 	struct rad_salted_value salted;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &z_radh, &data, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &z_radh, &data, &len) == FAILURE) {
 		return;
 	}
 
@@ -884,7 +884,7 @@ PHP_FUNCTION(radius_request_authenticator)
 	char buf[LEN_AUTH];
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &z_radh) == FAILURE) {
 		return;
 	}
 
@@ -906,7 +906,7 @@ PHP_FUNCTION(radius_server_secret)
 	struct rad_handle *radh;
 	zval *z_radh;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &z_radh) == FAILURE) {
 		return;
 	}
 
@@ -931,7 +931,7 @@ PHP_FUNCTION(radius_demangle)
 	COMPAT_ARG_SIZE_T len;
 	int res;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &z_radh, &mangled, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &z_radh, &mangled, &len) == FAILURE) {
 		return;
 	}
 
@@ -962,7 +962,7 @@ PHP_FUNCTION(radius_demangle_mppe_key)
 	COMPAT_ARG_SIZE_T len;
 	int res;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &z_radh, &mangled, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs", &z_radh, &mangled, &len) == FAILURE) {
 		return;
 	}
 
@@ -1004,7 +1004,7 @@ int _init_options(struct rad_attr_options *out, int options, int tag) {
 /* }}} */
 
 /* {{{ _radius_close() */
-void _radius_close(zend_resource *res TSRMLS_DC)
+void _radius_close(zend_resource *res)
 {
 	struct rad_handle *radh = (struct rad_handle *)res->ptr;
 	rad_close(radh);

--- a/radius.c
+++ b/radius.c
@@ -49,10 +49,17 @@ any other GPL-like (LGPL, GPL2) License.
 #include <arpa/inet.h>
 #endif
 
-void _radius_close(zend_rsrc_list_entry *rsrc TSRMLS_DC);
+#include "pecl-compat/compat.h"
+
+void _radius_close(zend_resource *res TSRMLS_DC);
 
 static int _init_options(struct rad_attr_options *out, int options, int tag);
 
+#define RADIUS_FETCH_RESOURCE(radh, zv) \
+	radh = (struct rad_handle *)compat_zend_fetch_resource(zv, "rad_handle", le_radius TSRMLS_CC); \
+	if (!radh) { \
+		RETURN_FALSE; \
+	}
 
 /* If you declare any globals in php_radius.h uncomment this:
 ZEND_DECLARE_MODULE_GLOBALS(radius)
@@ -312,34 +319,26 @@ PHP_MINFO_FUNCTION(radius)
 }
 /* }}} */
 
-/* {{{ proto ressource radius_auth_open(string arg) */
+/* {{{ proto resource radius_auth_open(string arg) */
 PHP_FUNCTION(radius_auth_open)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh = rad_auth_open();
 
-	raddesc = emalloc(sizeof(radius_descriptor));
-	raddesc->radh = rad_auth_open();
-
-	if (raddesc->radh != NULL) {
-		ZEND_REGISTER_RESOURCE(return_value, raddesc, le_radius);
-		raddesc->id = Z_LVAL_P(return_value);
+	if (radh != NULL) {
+		compat_zend_register_resource(return_value, radh, le_radius TSRMLS_CC);
 	} else {
 		RETURN_FALSE;
 	}
 }
 /* }}} */
 
-/* {{{ proto ressource radius_acct_open(string arg) */
+/* {{{ proto resource radius_acct_open(string arg) */
 PHP_FUNCTION(radius_acct_open)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh = rad_acct_open();
 
-	raddesc = emalloc(sizeof(radius_descriptor));
-	raddesc->radh = rad_acct_open();
-
-	if (raddesc->radh != NULL) {
-		ZEND_REGISTER_RESOURCE(return_value, raddesc, le_radius);
-		raddesc->id = Z_LVAL_P(return_value);
+	if (radh != NULL) {
+		compat_zend_register_resource(return_value, radh, le_radius TSRMLS_CC);
 	} else {
 		RETURN_FALSE;
 	}
@@ -349,15 +348,16 @@ PHP_FUNCTION(radius_acct_open)
 /* {{{ proto bool radius_close(radh) */
 PHP_FUNCTION(radius_close)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
-	zend_list_delete(raddesc->id);
+	/* Fetch the resource to verify it. */
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
+	compat_zend_delete_resource(z_radh TSRMLS_CC);
 	RETURN_TRUE;
 }
 /* }}} */
@@ -366,16 +366,16 @@ PHP_FUNCTION(radius_close)
 PHP_FUNCTION(radius_strerror)
 {
 	char *msg;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
-	msg = (char *)rad_strerror(raddesc->radh);
-	RETURN_STRINGL(msg, strlen(msg), 1);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
+	msg = (char *)rad_strerror(radh);
+	RETURN_STRINGL(msg, strlen(msg));
 }
 /* }}} */
 
@@ -383,17 +383,17 @@ PHP_FUNCTION(radius_strerror)
 PHP_FUNCTION(radius_config)
 {
 	char *filename;
-	int filename_len;
-	radius_descriptor *raddesc;
+	COMPAT_ARG_SIZE_T filename_len;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &z_radh, &filename, &filename_len) == FAILURE) {
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
-	if (rad_config(raddesc->radh, filename) == -1) {
+	if (rad_config(radh, filename) == -1) {
 		RETURN_FALSE;
 	} else {
 		RETURN_TRUE;
@@ -405,9 +405,9 @@ PHP_FUNCTION(radius_config)
 PHP_FUNCTION(radius_add_server)
 {
 	char *hostname, *secret;
-	int hostname_len, secret_len;
+	COMPAT_ARG_SIZE_T hostname_len, secret_len;
 	long  port, timeout, maxtries;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rslsll", &z_radh,
@@ -418,9 +418,9 @@ PHP_FUNCTION(radius_add_server)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
-	if (rad_add_server(raddesc->radh, hostname, port, secret, timeout, maxtries) == -1) {
+	if (rad_add_server(radh, hostname, port, secret, timeout, maxtries) == -1) {
 		RETURN_FALSE;
 	} else {
 		RETURN_TRUE;
@@ -432,16 +432,16 @@ PHP_FUNCTION(radius_add_server)
 PHP_FUNCTION(radius_create_request)
 {
 	long code;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &z_radh, &code) == FAILURE) {
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
-	if (rad_create_request(raddesc->radh, code) == -1) {
+	if (rad_create_request(radh, code) == -1) {
 		RETURN_FALSE;
 	} else {
 		RETURN_TRUE;
@@ -453,10 +453,10 @@ PHP_FUNCTION(radius_create_request)
 PHP_FUNCTION(radius_put_string)
 {
 	char *str;
-	int str_len;
+	COMPAT_ARG_SIZE_T str_len;
 	long type, options = 0, tag = 0;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rls|ll", &z_radh, &type, &str, &str_len, &options, &tag)
@@ -464,11 +464,11 @@ PHP_FUNCTION(radius_put_string)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_string(raddesc->radh, type, str, &attr_options) == -1) {
+	} else if (rad_put_string(radh, type, str, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -481,7 +481,7 @@ PHP_FUNCTION(radius_put_int)
 {
 	long type, val, options = 0, tag = 0;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rll|ll", &z_radh, &type, &val, &options, &tag)
@@ -489,11 +489,11 @@ PHP_FUNCTION(radius_put_int)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_int(raddesc->radh, type, val, &attr_options) == -1) {
+	} else if (rad_put_int(radh, type, val, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -505,10 +505,10 @@ PHP_FUNCTION(radius_put_int)
 PHP_FUNCTION(radius_put_attr)
 {
 	long type, options = 0, tag = 0;
-	int len;
+	COMPAT_ARG_SIZE_T len;
 	char *data;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rls|ll", &z_radh, &type, &data, &len, &options, &tag)
@@ -516,11 +516,11 @@ PHP_FUNCTION(radius_put_attr)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_attr(raddesc->radh, type, data, len, &attr_options) == -1) {
+	} else if (rad_put_attr(radh, type, data, len, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -532,11 +532,11 @@ PHP_FUNCTION(radius_put_attr)
 /* {{{ proto bool radius_put_addr(desc, type, addr, options, tag) */
 PHP_FUNCTION(radius_put_addr)
 {
-	int addrlen;
+	COMPAT_ARG_SIZE_T addrlen;
 	long type, options = 0, tag = 0;
 	char	*addr;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 	struct in_addr intern_addr;
 
@@ -545,7 +545,7 @@ PHP_FUNCTION(radius_put_addr)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (inet_aton(addr, &intern_addr) == 0) {
 		zend_error(E_ERROR, "Error converting Address");
@@ -554,7 +554,7 @@ PHP_FUNCTION(radius_put_addr)
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_addr(raddesc->radh, type, intern_addr, &attr_options) == -1) {
+	} else if (rad_put_addr(radh, type, intern_addr, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -566,10 +566,10 @@ PHP_FUNCTION(radius_put_addr)
 PHP_FUNCTION(radius_put_vendor_string)
 {
 	char *str;
-	int str_len;
+	COMPAT_ARG_SIZE_T str_len;
 	long type, vendor, options = 0, tag = 0;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlls|ll", &z_radh, &vendor, &type, &str, &str_len, &options, &tag)
@@ -577,11 +577,11 @@ PHP_FUNCTION(radius_put_vendor_string)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_vendor_string(raddesc->radh, vendor, type, str, &attr_options) == -1) {
+	} else if (rad_put_vendor_string(radh, vendor, type, str, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -594,7 +594,7 @@ PHP_FUNCTION(radius_put_vendor_int)
 {
 	long type, vendor, val, options = 0, tag = 0;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlll|ll", &z_radh, &vendor, &type, &val, &options, &tag)
@@ -602,11 +602,11 @@ PHP_FUNCTION(radius_put_vendor_int)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_vendor_int(raddesc->radh, vendor, type, val, &attr_options) == -1) {
+	} else if (rad_put_vendor_int(radh, vendor, type, val, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -618,10 +618,10 @@ PHP_FUNCTION(radius_put_vendor_int)
 PHP_FUNCTION(radius_put_vendor_attr)
 {
 	long type, vendor, options = 0, tag = 0;
-	int len;
+	COMPAT_ARG_SIZE_T len;
 	char *data;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rlls|ll", &z_radh, &vendor, &type,
@@ -629,11 +629,11 @@ PHP_FUNCTION(radius_put_vendor_attr)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_vendor_attr(raddesc->radh, vendor, type, data, len, &attr_options) == -1) {
+	} else if (rad_put_vendor_attr(radh, vendor, type, data, len, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -645,10 +645,10 @@ PHP_FUNCTION(radius_put_vendor_attr)
 PHP_FUNCTION(radius_put_vendor_addr)
 {
 	long type, vendor, options = 0, tag = 0;
-	int addrlen;
+	COMPAT_ARG_SIZE_T addrlen;
 	char	*addr;
 	struct rad_attr_options attr_options;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 	struct in_addr intern_addr;
 
@@ -657,7 +657,7 @@ PHP_FUNCTION(radius_put_vendor_addr)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	if (inet_aton(addr, &intern_addr) == 0) {
 		zend_error(E_ERROR, "Error converting Address");
@@ -666,7 +666,7 @@ PHP_FUNCTION(radius_put_vendor_addr)
 
 	if (_init_options(&attr_options, options, tag) == -1) {
 		RETURN_FALSE;
-	} else if (rad_put_vendor_addr(raddesc->radh, vendor, type, intern_addr, &attr_options) == -1) {
+	} else if (rad_put_vendor_addr(radh, vendor, type, intern_addr, &attr_options) == -1) {
 		RETURN_FALSE;
 	}
 
@@ -677,7 +677,7 @@ PHP_FUNCTION(radius_put_vendor_addr)
 /* {{{ proto bool radius_send_request(desc) */
 PHP_FUNCTION(radius_send_request)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 	int res;
 
@@ -686,9 +686,9 @@ PHP_FUNCTION(radius_send_request)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
-	res = rad_send_request(raddesc->radh);
+	res = rad_send_request(radh);
 	if (res == -1) {
 		RETURN_FALSE;
 	} else {
@@ -700,7 +700,7 @@ PHP_FUNCTION(radius_send_request)
 /* {{{ proto string radius_get_attr(desc) */
 PHP_FUNCTION(radius_get_attr)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	int res;
 	const void *data;
 	size_t len;
@@ -710,9 +710,9 @@ PHP_FUNCTION(radius_get_attr)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
-	res = rad_get_attr(raddesc->radh, &data, &len);
+	res = rad_get_attr(radh, &data, &len);
 	if (res == -1) {
 		RETURN_FALSE;
 	} else {
@@ -720,7 +720,7 @@ PHP_FUNCTION(radius_get_attr)
 
 			array_init(return_value);
 			add_assoc_long(return_value, "attr", res);
-			add_assoc_stringl(return_value, "data", (char *) data, len, 1);
+			add_assoc_stringl(return_value, "data", (char *) data, len);
 			return;
 		}
 		RETURN_LONG(res);
@@ -732,7 +732,7 @@ PHP_FUNCTION(radius_get_attr)
 PHP_FUNCTION(radius_get_tagged_attr_data)
 {
 	const char *attr;
-	int len;
+	COMPAT_ARG_SIZE_T len;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &attr, &len) == FAILURE) {
 		return;
@@ -745,7 +745,7 @@ PHP_FUNCTION(radius_get_tagged_attr_data)
 		RETURN_EMPTY_STRING();
 	}
 
-	RETURN_STRINGL(attr + 1, len - 1, 1);
+	RETURN_STRINGL(attr + 1, len - 1);
 }
 /* }}} */
 
@@ -753,7 +753,7 @@ PHP_FUNCTION(radius_get_tagged_attr_data)
 PHP_FUNCTION(radius_get_tagged_attr_tag)
 {
 	const char *attr;
-	int len;
+	COMPAT_ARG_SIZE_T len;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &attr, &len) == FAILURE) {
 		return;
@@ -772,7 +772,7 @@ PHP_FUNCTION(radius_get_tagged_attr_tag)
 PHP_FUNCTION(radius_get_vendor_attr)
 {
 	const void *data, *raw;
-	int len;
+	COMPAT_ARG_SIZE_T len;
 	u_int32_t vendor;
 	unsigned char type;
 	size_t data_len;
@@ -788,7 +788,7 @@ PHP_FUNCTION(radius_get_vendor_attr)
 		array_init(return_value);
 		add_assoc_long(return_value, "attr", type);
 		add_assoc_long(return_value, "vendor", vendor);
-		add_assoc_stringl(return_value, "data", (char *) data, data_len, 1);
+		add_assoc_stringl(return_value, "data", (char *) data, data_len);
 		return;
 	}
 }
@@ -799,7 +799,7 @@ PHP_FUNCTION(radius_cvt_addr)
 {
 	const void *data;
 	char *addr_dot;
-	int len;
+	COMPAT_ARG_SIZE_T len;
 	struct in_addr addr;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &len) == FAILURE) {
@@ -808,7 +808,7 @@ PHP_FUNCTION(radius_cvt_addr)
 
 	addr = rad_cvt_addr(data);
 	addr_dot = inet_ntoa(addr);
-	RETURN_STRINGL(addr_dot, strlen(addr_dot), 1);
+	RETURN_STRINGL(addr_dot, strlen(addr_dot));
 }
 /* }}} */
 
@@ -816,7 +816,8 @@ PHP_FUNCTION(radius_cvt_addr)
 PHP_FUNCTION(radius_cvt_int)
 {
 	const void *data;
-	int len, val;
+	COMPAT_ARG_SIZE_T len;
+	int val;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &len)
 		== FAILURE) {
@@ -833,7 +834,7 @@ PHP_FUNCTION(radius_cvt_string)
 {
 	const void *data;
 	char *val;
-	int len;
+	COMPAT_ARG_SIZE_T len;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &len)
 		== FAILURE) {
@@ -842,7 +843,7 @@ PHP_FUNCTION(radius_cvt_string)
 
 	val = rad_cvt_string(data, len);
 	if (val == NULL) RETURN_FALSE;
-	RETVAL_STRINGL(val, strlen(val), 1);
+	RETVAL_STRINGL(val, strlen(val));
 	free(val);
 	return;
 }
@@ -852,8 +853,8 @@ PHP_FUNCTION(radius_cvt_string)
 PHP_FUNCTION(radius_salt_encrypt_attr)
 {
 	char *data;
-	int len;
-	radius_descriptor *raddesc;
+	COMPAT_ARG_SIZE_T len;
+	struct rad_handle *radh;
 	struct rad_salted_value salted;
 	zval *z_radh;
 
@@ -861,16 +862,16 @@ PHP_FUNCTION(radius_salt_encrypt_attr)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
-	if (rad_salt_value(raddesc->radh, data, len, &salted) == -1) {
-		zend_error(E_WARNING, "%s", rad_strerror(raddesc->radh));
+	if (rad_salt_value(radh, data, len, &salted) == -1) {
+		zend_error(E_WARNING, "%s", rad_strerror(radh));
 		RETURN_FALSE;
 	} else if (salted.len == 0) {
 		RETURN_EMPTY_STRING();
 	}
 
-	RETVAL_STRINGL(salted.data, salted.len, 1);
+	RETVAL_STRINGL(salted.data, salted.len);
 	efree(salted.data);
 }
 /* }}} */
@@ -878,7 +879,7 @@ PHP_FUNCTION(radius_salt_encrypt_attr)
 /* {{{ proto string radius_request_authenticator(radh) */
 PHP_FUNCTION(radius_request_authenticator)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	ssize_t res;
 	char buf[LEN_AUTH];
 	zval *z_radh;
@@ -887,13 +888,13 @@ PHP_FUNCTION(radius_request_authenticator)
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
-	res = rad_request_authenticator(raddesc->radh, buf, sizeof buf);
+	res = rad_request_authenticator(radh, buf, sizeof buf);
 	if (res == -1) {
 		RETURN_FALSE;
 	} else {
-		RETURN_STRINGL(buf, res, 1);
+		RETURN_STRINGL(buf, res);
 	}
 }
 /* }}} */
@@ -902,18 +903,18 @@ PHP_FUNCTION(radius_request_authenticator)
 PHP_FUNCTION(radius_server_secret)
 {
 	char *secret;
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &z_radh) == FAILURE) {
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
-	secret = (char *)rad_server_secret(raddesc->radh);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
+	secret = (char *)rad_server_secret(radh);
 
 	if (secret) {
-		RETURN_STRINGL(secret, strlen(secret), 1);
+		RETURN_STRINGL(secret, strlen(secret));
 	}
 
 	RETURN_FALSE;
@@ -923,26 +924,27 @@ PHP_FUNCTION(radius_server_secret)
 /* {{{ proto string radius_demangle(radh, mangled) */
 PHP_FUNCTION(radius_demangle)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 	const void *mangled;
 	unsigned char *buf;
-	int len, res;
+	COMPAT_ARG_SIZE_T len;
+	int res;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &z_radh, &mangled, &len) == FAILURE) {
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	buf = emalloc(len);
-	res = rad_demangle(raddesc->radh, mangled, len, buf);
+	res = rad_demangle(radh, mangled, len, buf);
 
 	if (res == -1) {
 		efree(buf);
 		RETURN_FALSE;
 	} else {
-		RETVAL_STRINGL((char *) buf, len, 1);
+		RETVAL_STRINGL((char *) buf, len);
 		efree(buf);
 		return;
 	}
@@ -952,26 +954,27 @@ PHP_FUNCTION(radius_demangle)
 /* {{{ proto string radius_demangle_mppe_key(radh, mangled) */
 PHP_FUNCTION(radius_demangle_mppe_key)
 {
-	radius_descriptor *raddesc;
+	struct rad_handle *radh;
 	zval *z_radh;
 	const void *mangled;
 	unsigned char *buf;
 	size_t dlen;
-	int len, res;
+	COMPAT_ARG_SIZE_T len;
+	int res;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &z_radh, &mangled, &len) == FAILURE) {
 		return;
 	}
 
-	ZEND_FETCH_RESOURCE(raddesc, radius_descriptor *, &z_radh, -1, "rad_handle", le_radius);
+	RADIUS_FETCH_RESOURCE(radh, z_radh);
 
 	buf = emalloc(len);
-	res = rad_demangle_mppe_key(raddesc->radh, mangled, len, buf, &dlen);
+	res = rad_demangle_mppe_key(radh, mangled, len, buf, &dlen);
 	if (res == -1) {
 		efree(buf);
 		RETURN_FALSE;
 	} else {
-		RETVAL_STRINGL((char *) buf, dlen, 1);
+		RETVAL_STRINGL((char *) buf, dlen);
 		efree(buf);
 		return;
 	}
@@ -1001,11 +1004,11 @@ int _init_options(struct rad_attr_options *out, int options, int tag) {
 /* }}} */
 
 /* {{{ _radius_close() */
-void _radius_close(zend_rsrc_list_entry *rsrc TSRMLS_DC)
+void _radius_close(zend_resource *res TSRMLS_DC)
 {
-	radius_descriptor *raddesc = (radius_descriptor *)rsrc->ptr;
-	rad_close(raddesc->radh);
-	efree(raddesc);
+	struct rad_handle *radh = (struct rad_handle *)res->ptr;
+	rad_close(radh);
+	res->ptr = NULL;
 }
 /* }}} */
 

--- a/radlib.c
+++ b/radlib.c
@@ -581,8 +581,7 @@ rad_create_request(struct rad_handle *h, int code)
 	/* Create a random authenticator */
 	for (i = 0;  i < LEN_AUTH;  i += 2) {
 		long r;
-		TSRMLS_FETCH();
-		r = php_rand(TSRMLS_C);
+		r = php_rand();
 		h->request[POS_AUTH+i] = (unsigned char) r;
 		h->request[POS_AUTH+i+1] = (unsigned char) (r >> 8);
 	}
@@ -749,11 +748,10 @@ rad_auth_open(void)
 
 	h = (struct rad_handle *)malloc(sizeof(struct rad_handle));
 	if (h != NULL) {
-		TSRMLS_FETCH();
-		php_srand(time(NULL) * getpid() * (unsigned long) (php_combined_lcg(TSRMLS_C) * 10000.0) TSRMLS_CC);
+		php_srand(time(NULL) * getpid() * (unsigned long) (php_combined_lcg(NULL) * 10000.0));
 		h->fd = -1;
 		h->num_servers = 0;
-		h->ident = php_rand(TSRMLS_C);
+		h->ident = php_rand();
 		h->errmsg[0] = '\0';
 		memset(h->request, 0, sizeof h->request);
 		h->req_len = 0;
@@ -1242,7 +1240,6 @@ int rad_salt_value(struct rad_handle *h, const char *in, size_t len, struct rad_
 	php_uint32 random;
 	size_t salted_len;
 	const char *secret;
-	TSRMLS_FETCH();
 
 	if (len == 0) {
 		out->len = 0;
@@ -1289,7 +1286,7 @@ int rad_salt_value(struct rad_handle *h, const char *in, size_t len, struct rad_
 	}
 
 	/* Generate a random number to use as the salt. */
-	random = php_rand(TSRMLS_C);
+	random = php_rand();
 
 	/* The RFC requires that the high bit of the salt be 1. Otherwise,
 	 * let's set up the header. */

--- a/tests/coa.phpt
+++ b/tests/coa.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,31 +15,31 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_COA_REQUEST;
 $response->attributes = array(
-    Attribute::expect(RADIUS_FILTER_ID, 'filter'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_FILTER_ID, 'filter'),
 );
 
 $server->addTransaction($request, $response);
 
-$request = Request::expect(RADIUS_COA_NAK, array(
-    Attribute::expect(RADIUS_ERROR_CAUSE, pack('N', RADIUS_ERROR_CAUSE_MISSING_ATTRIBUTE)),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_COA_NAK, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_ERROR_CAUSE, pack('N', RADIUS_ERROR_CAUSE_MISSING_ATTRIBUTE)),
 ));
 
 $server->addTransaction($request, $response);
 
-$request = Request::expect(RADIUS_COA_ACK, array(
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_COA_ACK, array(
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_COA_ACK;
 
 $server->addTransaction($request, $response);

--- a/tests/disconnect.phpt
+++ b/tests/disconnect.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,31 +15,31 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_DISCONNECT_REQUEST;
 $response->attributes = array(
-    Attribute::expect(RADIUS_NAS_IDENTIFIER, 'NAS'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_NAS_IDENTIFIER, 'NAS'),
 );
 
 $server->addTransaction($request, $response);
 
-$request = Request::expect(RADIUS_DISCONNECT_NAK, array(
-    Attribute::expect(RADIUS_ERROR_CAUSE, pack('N', RADIUS_ERROR_CAUSE_MISSING_ATTRIBUTE)),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_DISCONNECT_NAK, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_ERROR_CAUSE, pack('N', RADIUS_ERROR_CAUSE_MISSING_ATTRIBUTE)),
 ));
 
 $server->addTransaction($request, $response);
 
-$request = Request::expect(RADIUS_DISCONNECT_ACK, array(
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_DISCONNECT_ACK, array(
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_DISCONNECT_ACK;
 
 $server->addTransaction($request, $response);

--- a/tests/radius_get_attr.phpt
+++ b/tests/radius_get_attr.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,17 +15,17 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_addr.phpt
+++ b/tests/radius_put_addr.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    Attribute::expect(RADIUS_NAS_IP_ADDRESS, pack('N', ip2long('127.0.0.1'))),
-    Attribute::expect(RADIUS_LOGIN_IP_HOST, pack('N', ip2long('0.0.0.0')), null, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_NAS_IP_ADDRESS, pack('N', ip2long('127.0.0.1'))),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_IP_HOST, pack('N', ip2long('0.0.0.0')), null, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_addr_tag.phpt
+++ b/tests/radius_put_addr_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    Attribute::expect(RADIUS_NAS_IP_ADDRESS, pack('N', ip2long('127.0.0.1')), 10),
-    Attribute::expect(RADIUS_LOGIN_IP_HOST, pack('N', ip2long('0.0.0.0')), 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_NAS_IP_ADDRESS, pack('N', ip2long('127.0.0.1')), 10),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_IP_HOST, pack('N', ip2long('0.0.0.0')), 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_attr.phpt
+++ b/tests/radius_put_attr.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    Attribute::expect(RADIUS_LOGIN_IP_HOST, 'bar', null, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_IP_HOST, 'bar', null, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_attr_tag.phpt
+++ b/tests/radius_put_attr_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo', 10),
-    Attribute::expect(RADIUS_LOGIN_IP_HOST, 'bar', 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo', 10),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_IP_HOST, 'bar', 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_int.phpt
+++ b/tests/radius_put_int.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    Attribute::expect(RADIUS_NAS_PORT, pack('N', 1234)),
-    Attribute::expect(RADIUS_LOGIN_TCP_PORT, pack('N', 2345), null, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_NAS_PORT, pack('N', 1234)),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_TCP_PORT, pack('N', 2345), null, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_int_tag.phpt
+++ b/tests/radius_put_int_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    Attribute::expect(RADIUS_NAS_PORT, pack('N', 1234), 10),
-    Attribute::expect(RADIUS_LOGIN_TCP_PORT, pack('N', 2345), 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_NAS_PORT, pack('N', 1234), 10),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_TCP_PORT, pack('N', 2345), 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_string.phpt
+++ b/tests/radius_put_string.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    Attribute::expect(RADIUS_LOGIN_IP_HOST, 'abcdefghijklmnopqrstuvwxyz', null, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_IP_HOST, 'abcdefghijklmnopqrstuvwxyz', null, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_string_tag.phpt
+++ b/tests/radius_put_string_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo', 10),
-    Attribute::expect(RADIUS_LOGIN_IP_HOST, 'abcdefghijklmnopqrstuvwxyz', 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo', 10),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_LOGIN_IP_HOST, 'abcdefghijklmnopqrstuvwxyz', 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_addr.phpt
+++ b/tests/radius_put_vendor_addr.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1'))),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1')), null, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1'))),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1')), null, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_addr_tag.phpt
+++ b/tests/radius_put_vendor_addr_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1')), 10),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1')), 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1')), 10),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, pack('N', ip2long('127.0.0.1')), 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_attr.phpt
+++ b/tests/radius_put_vendor_attr.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor'),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', null, 10),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor'),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', null, 10),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_attr_tag.phpt
+++ b/tests/radius_put_vendor_attr_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', 10),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, 'vendor', 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', 10),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER, 'vendor', 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_int.phpt
+++ b/tests/radius_put_vendor_int.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234)),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234), null, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234)),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234), null, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_int_tag.phpt
+++ b/tests/radius_put_vendor_int_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,19 +15,19 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    Attribute::expect(RADIUS_USER_NAME, 'foo'),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234), 10),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234), 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_USER_NAME, 'foo'),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234), 10),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VERSION, pack('N', 1234), 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_string.phpt
+++ b/tests/radius_put_vendor_string.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor'),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', null, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor'),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', null, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);

--- a/tests/radius_put_vendor_string_tag.phpt
+++ b/tests/radius_put_vendor_string_tag.phpt
@@ -7,7 +7,7 @@ error_reporting=22527
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-if (FakeServer::skip()) {
+if (\RADIUS\FakeServer\FakeServer::skip()) {
     die('SKIP: pcntl, radius and sockets extensions required');
 }
 ?>
@@ -15,18 +15,18 @@ if (FakeServer::skip()) {
 <?php
 include dirname(__FILE__).'/server/fake_server.php';
 
-$server = new FakeServer;
+$server = new \RADIUS\FakeServer\FakeServer;
 $res = $server->getAuthResource();
 
-$request = Request::expect(RADIUS_ACCESS_REQUEST, array(
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', 10),
-    VendorSpecificAttribute::expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', 10, true),
+$request = \RADIUS\FakeServer\Request::expect(RADIUS_ACCESS_REQUEST, array(
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', 10),
+    \RADIUS\FakeServer\VendorSpecificAttribute\expect(RADIUS_VENDOR_MICROSOFT, RADIUS_MICROSOFT_MS_RAS_VENDOR, 'vendor', 10, true),
 ));
 
-$response = new RadiusResponse;
+$response = new \RADIUS\FakeServer\RadiusResponse;
 $response->code = RADIUS_ACCESS_REJECT;
 $response->attributes = array(
-    Attribute::expect(RADIUS_REPLY_MESSAGE, 'Go away'),
+    \RADIUS\FakeServer\Attribute\expect(RADIUS_REPLY_MESSAGE, 'Go away'),
 );
 
 $server->addTransaction($request, $response);


### PR DESCRIPTION
Remaining fixes to make master compile with PHP 8.2
- https://github.com/toolsforresearch/php-radius/commit/41831324f4789175644b8d538d49abdc564f324d Import https://pecl.php.net/get/radius-1.4.0b1.tgz
- https://github.com/toolsforresearch/php-radius/commit/aceb2035a97aa6f92b30a98b893a1123afe587d4 Remove the TSRMLS macro's, that are not used in PHP 7+ anyway

Compilation with Windows (VS16) is on the way and will be published at https://www.apachelounge.com/viewtopic.php?t=6617
For *nix: `git clone -b php-8.2 https://github.com/toolsforresearch/php-radius`