### PR TITLE
Create stubs file; fix clang warnings.

### DIFF
--- a/radius.c
+++ b/radius.c
@@ -42,6 +42,7 @@ any other GPL-like (LGPL, GPL2) License.
 #include "php_radius.h"
 #include "radlib.h"
 #include "radlib_private.h"
+#include "radius_arginfo.h"
 
 #ifndef PHP_WIN32
 #include <sys/socket.h>
@@ -68,203 +69,6 @@ ZEND_DECLARE_MODULE_GLOBALS(radius)
 /* True global resources - no need for thread safety here */
 static int le_radius;
 
-/* {{{ arginfo */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_auth_open, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_acct_open, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_close, 0, 0, 1)
-	ZEND_ARG_INFO(0, radius_handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_strerror, 0, 0, 1)
-	ZEND_ARG_INFO(0, radius_handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_config, 0, 0, 2)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, file)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_add_server, 0, 0, 6)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, hostname)
-	ZEND_ARG_INFO(0, port)
-	ZEND_ARG_INFO(0, secret)
-	ZEND_ARG_INFO(0, timeout)
-	ZEND_ARG_INFO(0, max_tries)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_create_request, 0, 0, 2)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, type)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_string, 0, 0, 3)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_int, 0, 0, 3)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_attr, 0, 0, 3)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_addr, 0, 0, 3)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, addr)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_vendor_string, 0, 0, 4)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, vendor)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_vendor_int, 0, 0, 4)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, vendor)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_vendor_attr, 0, 0, 4)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, vendor)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_put_vendor_addr, 0, 0, 4)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, vendor)
-	ZEND_ARG_INFO(0, type)
-	ZEND_ARG_INFO(0, addr)
-	ZEND_ARG_INFO(0, options)
-	ZEND_ARG_INFO(0, tag)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_send_request, 0, 0, 1)
-	ZEND_ARG_INFO(0, radius_handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_get_attr, 0, 0, 1)
-	ZEND_ARG_INFO(0, radius_handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_get_tagged_attr_data, 0, 0, 1)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_get_tagged_attr_tag, 0, 0, 1)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_get_vendor_attr, 0, 0, 1)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_cvt_addr, 0, 0, 1)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_cvt_int, 0, 0, 1)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_cvt_string, 0, 0, 1)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_salt_encrypt_attr, 0, 0, 2)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_request_authenticator, 0, 0, 1)
-	ZEND_ARG_INFO(0, radius_handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_server_secret, 0, 0, 1)
-	ZEND_ARG_INFO(0, radius_handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_demangle, 0, 0, 2)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, mangled)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_demangle_mppe_key, 0, 0, 2)
-	ZEND_ARG_INFO(0, radius_handle)
-	ZEND_ARG_INFO(0, mangled)
-ZEND_END_ARG_INFO()
-
-/* }}} */
-
-
-/* {{{ radius_functions[]
- *
- * Every user visible function must have an entry in radius_functions[].
- */
-zend_function_entry radius_functions[] = {
-	PHP_FE(radius_auth_open,    arginfo_radius_auth_open)
-	PHP_FE(radius_acct_open,    arginfo_radius_acct_open)
-	PHP_FE(radius_close,        arginfo_radius_close)
-	PHP_FE(radius_strerror,     arginfo_radius_strerror)
-	PHP_FE(radius_config,       arginfo_radius_config)
-	PHP_FE(radius_add_server,	arginfo_radius_add_server)
-	PHP_FE(radius_create_request,	arginfo_radius_create_request)
-	PHP_FE(radius_put_string,	arginfo_radius_put_string)
-	PHP_FE(radius_put_int,	arginfo_radius_put_int)
-	PHP_FE(radius_put_attr,	arginfo_radius_put_attr)
-	PHP_FE(radius_put_addr,	arginfo_radius_put_addr)
-	PHP_FE(radius_put_vendor_string,	arginfo_radius_put_vendor_string)
-	PHP_FE(radius_put_vendor_int,	arginfo_radius_put_vendor_int)
-	PHP_FE(radius_put_vendor_attr,	arginfo_radius_put_vendor_attr)
-	PHP_FE(radius_put_vendor_addr,	arginfo_radius_put_vendor_addr)
-	PHP_FE(radius_send_request,	arginfo_radius_get_attr)
-	PHP_FE(radius_get_attr,	arginfo_radius_get_attr)
-	PHP_FE(radius_get_tagged_attr_data, arginfo_radius_get_tagged_attr_data)
-	PHP_FE(radius_get_tagged_attr_tag, arginfo_radius_get_tagged_attr_tag)
-	PHP_FE(radius_get_vendor_attr,	arginfo_radius_get_vendor_attr)
-	PHP_FE(radius_cvt_addr,	arginfo_radius_cvt_addr)
-	PHP_FE(radius_cvt_int,	arginfo_radius_cvt_int)
-	PHP_FE(radius_cvt_string,	arginfo_radius_cvt_string)
-	PHP_FE(radius_salt_encrypt_attr,	arginfo_radius_salt_encrypt_attr)
-	PHP_FE(radius_request_authenticator,	arginfo_radius_request_authenticator)
-	PHP_FE(radius_server_secret,	arginfo_radius_server_secret)
-	PHP_FE(radius_demangle,	arginfo_radius_demangle)
-	PHP_FE(radius_demangle_mppe_key,	arginfo_radius_demangle_mppe_key)
-	{NULL, NULL, NULL}	/* Must be the last line in radius_functions[] */
-};
-/* }}} */
-
 /* {{{ radius_module_entry
  */
 zend_module_entry radius_module_entry = {
@@ -272,7 +76,7 @@ zend_module_entry radius_module_entry = {
 	STANDARD_MODULE_HEADER,
 #endif
 	"radius",
-	radius_functions,
+	ext_functions,
 	PHP_MINIT(radius),
 	PHP_MSHUTDOWN(radius),
 	NULL,

--- a/radius.stub.php
+++ b/radius.stub.php
@@ -1,0 +1,126 @@
+<?php
+
+/** @generate-function-entries */
+
+/**
+ * @return resource|false
+ */
+function radius_acct_open ( ) {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_add_server ( $radius_handle , string $hostname , int $port , string $secret , int $timeout , int $max_tries ) : bool {}
+
+/**
+ * @return resource|false
+ */
+function radius_auth_open ( ) {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_close ( $radius_handle ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_config ( $radius_handle , string $file ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_create_request ( $radius_handle , int $type ) : bool {}
+
+function radius_cvt_addr ( string $data ) : string {}
+
+function radius_cvt_int ( string $data ) : int {}
+
+function radius_cvt_string ( string $data ) : string {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_demangle_mppe_key ( $radius_handle , string $mangled ) : string|false {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_demangle ( $radius_handle , string $mangled ) : string|false {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_get_attr ( $radius_handle ) : array|int {}
+
+function radius_get_tagged_attr_data ( string $data ) : string|false {}
+
+function radius_get_tagged_attr_tag ( string $data ) : int|false {}
+
+function radius_get_vendor_attr ( string $data ) : array|false {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_addr ( $radius_handle , int $type , string $address , ?int $options = 0 , int $tag = 0 ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_attr ( $radius_handle , int $type , string $value , ?int $options = 0 , int $tag = 0 ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_int ( $radius_handle , int $type , int $value , ?int $options = 0 , int $tag = 0 ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_string ( $radius_handle , int $type , string $value , ?int $options = 0 , int $tag = 0 ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_vendor_addr ( $radius_handle , int $vendor , int $type , string $address ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_vendor_attr ( $radius_handle , int $vendor , int $type , string $value , ?int $options = 0 , int $tag = 0 ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_vendor_int ( $radius_handle , int $vendor , int $type , int $value , ?int $options = 0 , int $tag = 0 ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_put_vendor_string ( $radius_handle , int $vendor , int $type , string $value , ?int $options = 0 , int $tag = 0 ) : bool {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_request_authenticator ( $radius_handle ) : string|false {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_salt_encrypt_attr ( $radius_handle , string $data ) : string|false {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_send_request ( $radius_handle ) : int|false {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_server_secret ( $radius_handle ) : string {}
+
+/**
+ * @param resource $radius_handle
+ */
+function radius_strerror ( $radius_handle ) : string {}
+

--- a/radius_arginfo.h
+++ b/radius_arginfo.h
@@ -1,0 +1,198 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 973da7dbc73579761a1424964eb63ea6d9035bef */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_radius_acct_open, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_add_server, 0, 6, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, port, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, secret, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, timeout, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, max_tries, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_radius_auth_open arginfo_radius_acct_open
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_close, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_config, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, file, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_create_request, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_cvt_addr, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_cvt_int, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_radius_cvt_string arginfo_radius_cvt_addr
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_demangle_mppe_key, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, mangled, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_radius_demangle arginfo_radius_demangle_mppe_key
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_get_attr, 0, 1, MAY_BE_ARRAY|MAY_BE_LONG)
+	ZEND_ARG_INFO(0, radius_handle)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_get_tagged_attr_data, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_get_tagged_attr_tag, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_get_vendor_attr, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_put_addr, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, address, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 1, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tag, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_put_attr, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 1, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tag, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_put_int, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 1, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tag, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+#define arginfo_radius_put_string arginfo_radius_put_attr
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_put_vendor_addr, 0, 4, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, vendor, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, address, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_put_vendor_attr, 0, 4, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, vendor, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 1, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tag, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_put_vendor_int, 0, 4, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, vendor, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 1, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tag, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+#define arginfo_radius_put_vendor_string arginfo_radius_put_vendor_attr
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_request_authenticator, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_INFO(0, radius_handle)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_salt_encrypt_attr, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_INFO(0, radius_handle)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_radius_send_request, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_INFO(0, radius_handle)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_radius_server_secret, 0, 1, IS_STRING, 0)
+	ZEND_ARG_INFO(0, radius_handle)
+ZEND_END_ARG_INFO()
+
+#define arginfo_radius_strerror arginfo_radius_server_secret
+
+
+ZEND_FUNCTION(radius_acct_open);
+ZEND_FUNCTION(radius_add_server);
+ZEND_FUNCTION(radius_auth_open);
+ZEND_FUNCTION(radius_close);
+ZEND_FUNCTION(radius_config);
+ZEND_FUNCTION(radius_create_request);
+ZEND_FUNCTION(radius_cvt_addr);
+ZEND_FUNCTION(radius_cvt_int);
+ZEND_FUNCTION(radius_cvt_string);
+ZEND_FUNCTION(radius_demangle_mppe_key);
+ZEND_FUNCTION(radius_demangle);
+ZEND_FUNCTION(radius_get_attr);
+ZEND_FUNCTION(radius_get_tagged_attr_data);
+ZEND_FUNCTION(radius_get_tagged_attr_tag);
+ZEND_FUNCTION(radius_get_vendor_attr);
+ZEND_FUNCTION(radius_put_addr);
+ZEND_FUNCTION(radius_put_attr);
+ZEND_FUNCTION(radius_put_int);
+ZEND_FUNCTION(radius_put_string);
+ZEND_FUNCTION(radius_put_vendor_addr);
+ZEND_FUNCTION(radius_put_vendor_attr);
+ZEND_FUNCTION(radius_put_vendor_int);
+ZEND_FUNCTION(radius_put_vendor_string);
+ZEND_FUNCTION(radius_request_authenticator);
+ZEND_FUNCTION(radius_salt_encrypt_attr);
+ZEND_FUNCTION(radius_send_request);
+ZEND_FUNCTION(radius_server_secret);
+ZEND_FUNCTION(radius_strerror);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(radius_acct_open, arginfo_radius_acct_open)
+	ZEND_FE(radius_add_server, arginfo_radius_add_server)
+	ZEND_FE(radius_auth_open, arginfo_radius_auth_open)
+	ZEND_FE(radius_close, arginfo_radius_close)
+	ZEND_FE(radius_config, arginfo_radius_config)
+	ZEND_FE(radius_create_request, arginfo_radius_create_request)
+	ZEND_FE(radius_cvt_addr, arginfo_radius_cvt_addr)
+	ZEND_FE(radius_cvt_int, arginfo_radius_cvt_int)
+	ZEND_FE(radius_cvt_string, arginfo_radius_cvt_string)
+	ZEND_FE(radius_demangle_mppe_key, arginfo_radius_demangle_mppe_key)
+	ZEND_FE(radius_demangle, arginfo_radius_demangle)
+	ZEND_FE(radius_get_attr, arginfo_radius_get_attr)
+	ZEND_FE(radius_get_tagged_attr_data, arginfo_radius_get_tagged_attr_data)
+	ZEND_FE(radius_get_tagged_attr_tag, arginfo_radius_get_tagged_attr_tag)
+	ZEND_FE(radius_get_vendor_attr, arginfo_radius_get_vendor_attr)
+	ZEND_FE(radius_put_addr, arginfo_radius_put_addr)
+	ZEND_FE(radius_put_attr, arginfo_radius_put_attr)
+	ZEND_FE(radius_put_int, arginfo_radius_put_int)
+	ZEND_FE(radius_put_string, arginfo_radius_put_string)
+	ZEND_FE(radius_put_vendor_addr, arginfo_radius_put_vendor_addr)
+	ZEND_FE(radius_put_vendor_attr, arginfo_radius_put_vendor_attr)
+	ZEND_FE(radius_put_vendor_int, arginfo_radius_put_vendor_int)
+	ZEND_FE(radius_put_vendor_string, arginfo_radius_put_vendor_string)
+	ZEND_FE(radius_request_authenticator, arginfo_radius_request_authenticator)
+	ZEND_FE(radius_salt_encrypt_attr, arginfo_radius_salt_encrypt_attr)
+	ZEND_FE(radius_send_request, arginfo_radius_send_request)
+	ZEND_FE(radius_server_secret, arginfo_radius_server_secret)
+	ZEND_FE(radius_strerror, arginfo_radius_strerror)
+	ZEND_FE_END
+};

--- a/radlib.c
+++ b/radlib.c
@@ -497,7 +497,7 @@ rad_continue_send_request(struct rad_handle *h, int selected, int *fd,
 
 	if (selected) {
 		struct sockaddr_in from;
-		int fromlen;
+		socklen_t fromlen;
 
 		fromlen = sizeof from;
 		h->resp_len = recvfrom(h->fd, h->response,
@@ -1033,7 +1033,7 @@ rad_put_vendor_attr(struct rad_handle *h, int vendor, int type,
 	/* OK, allocate and start building the attribute. */
 	attr = emalloc(va_len);
 	if (attr == NULL) {
-		generr(h, "malloc failure (%d bytes)", va_len);
+		generr(h, "malloc failure (%lu bytes)", va_len);
 		goto end;
 	}
 
@@ -1216,12 +1216,12 @@ rad_demangle_mppe_key(struct rad_handle *h, const void *mangled, size_t mlen, u_
 	*/
 	*len = *P;
 	if (*len > mlen - 1) {
-		generr(h, "Mangled data seems to be garbage %d %d", *len, mlen-1);        
+		generr(h, "Mangled data seems to be garbage %lu %lu", *len, mlen-1);
 		return -1;
 	}
 
 	if (*len > MPPE_KEY_LEN) {
-		generr(h, "Key to long (%d) for me max. %d", *len, MPPE_KEY_LEN);        
+		generr(h, "Key to long (%lu) for me max. %d", *len, MPPE_KEY_LEN);
 		return -1;
 	}
 
@@ -1233,7 +1233,7 @@ int rad_salt_value(struct rad_handle *h, const char *in, size_t len, struct rad_
 {
 	char authenticator[16];
 	size_t i;
-	char intermediate[16];
+	unsigned char intermediate[16];
 	const char *in_pos;
 	MD5_CTX md5;
 	char *out_pos;


### PR DESCRIPTION
Create stubs file and auto-generate `radius_arginfo.h` from it.
Fix warnings generated by clang.